### PR TITLE
Generate 'NOW()' rather than 'NOW'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   matrix:
     - NUO_VERSION=3.2.4.1 TABLE_LOCK=true
     - NUO_VERSION=3.2.4.1 TABLE_LOCK=false
+    - NUO_VERSION=3.4.0.1
 
 jdk:
   - openjdk8

--- a/core/src/main/java/com/nuodb/migrator/jdbc/dialect/NuoDBDialect.java
+++ b/core/src/main/java/com/nuodb/migrator/jdbc/dialect/NuoDBDialect.java
@@ -182,7 +182,7 @@ public class NuoDBDialect extends SimpleDialect {
                 newArrayList("CURRENT_TIMESTAMP", "CURRENT_TIMESTAMP()", "NOW()"), "CURRENT_TIMESTAMP", true));
         addTranslator(new CurrentTimestampTranslator(MYSQL,
                 newArrayList("CURRENT_TIMESTAMP", "CURRENT_TIMESTAMP()", "NOW()", "LOCALTIME", "LOCALTIME()",
-                        "LOCALTIMESTAMP", "LOCALTIMESTAMP()"), "NOW()"));
+                             "LOCALTIMESTAMP", "LOCALTIMESTAMP()"), "NOW()", true));
         addTranslator(new MySQLBitLiteralTranslator());
         addTranslator(new MySQLHexLiteralTranslator());
         addTranslator(new MySQLZeroDateTimeTranslator());
@@ -190,18 +190,18 @@ public class NuoDBDialect extends SimpleDialect {
         addTranslator(new MySQLOnUpdateTriggerTranslator());
 
         addTranslator(new CurrentTimestampTranslator(MSSQL_SERVER,
-                newArrayList("GETDATE()", "CURRENT_TIMESTAMP", "NOW()"), "NOW()"));
+                                                     newArrayList("GETDATE()", "CURRENT_TIMESTAMP", "NOW()"), "NOW()", true));
         addTranslationRegex(MSSQL_SERVER, "N'(.*)'", "$1");
 
         addTranslator(new CurrentTimestampTranslator(POSTGRE_SQL,
-                newArrayList("CURRENT_TIMESTAMP", "NOW()"), "NOW()"));
+                                                     newArrayList("CURRENT_TIMESTAMP", "NOW()"), "NOW()", true));
         addTranslationRegex(POSTGRE_SQL, "'(.*)'::.*", "$1");
 
         addTranslator(new CurrentTimestampTranslator(ORACLE,
-                newArrayList("CURRENT_DATE", "SYSDATE"), "NOW()"));
+                                                     newArrayList("CURRENT_DATE", "SYSDATE"), "NOW()", true));
 
         addTranslator(new CurrentTimestampTranslator(DB2,
-                newArrayList("CURRENT DATE", "CURRENT TIME", "CURRENT TIMESTAMP"), "NOW()"));
+                                                     newArrayList("CURRENT DATE", "CURRENT TIME", "CURRENT TIMESTAMP"), "NOW()", true));
     }
 
     @Override

--- a/core/src/main/java/com/nuodb/migrator/jdbc/dialect/NuoDBDialect.java
+++ b/core/src/main/java/com/nuodb/migrator/jdbc/dialect/NuoDBDialect.java
@@ -182,7 +182,7 @@ public class NuoDBDialect extends SimpleDialect {
                 newArrayList("CURRENT_TIMESTAMP", "CURRENT_TIMESTAMP()", "NOW()"), "CURRENT_TIMESTAMP", true));
         addTranslator(new CurrentTimestampTranslator(MYSQL,
                 newArrayList("CURRENT_TIMESTAMP", "CURRENT_TIMESTAMP()", "NOW()", "LOCALTIME", "LOCALTIME()",
-                        "LOCALTIMESTAMP", "LOCALTIMESTAMP()"), "NOW"));
+                        "LOCALTIMESTAMP", "LOCALTIMESTAMP()"), "NOW()"));
         addTranslator(new MySQLBitLiteralTranslator());
         addTranslator(new MySQLHexLiteralTranslator());
         addTranslator(new MySQLZeroDateTimeTranslator());
@@ -190,18 +190,18 @@ public class NuoDBDialect extends SimpleDialect {
         addTranslator(new MySQLOnUpdateTriggerTranslator());
 
         addTranslator(new CurrentTimestampTranslator(MSSQL_SERVER,
-                newArrayList("GETDATE()", "CURRENT_TIMESTAMP", "NOW()"), "NOW"));
+                newArrayList("GETDATE()", "CURRENT_TIMESTAMP", "NOW()"), "NOW()"));
         addTranslationRegex(MSSQL_SERVER, "N'(.*)'", "$1");
 
         addTranslator(new CurrentTimestampTranslator(POSTGRE_SQL,
-                newArrayList("CURRENT_TIMESTAMP", "NOW()"), "NOW"));
+                newArrayList("CURRENT_TIMESTAMP", "NOW()"), "NOW()"));
         addTranslationRegex(POSTGRE_SQL, "'(.*)'::.*", "$1");
 
         addTranslator(new CurrentTimestampTranslator(ORACLE,
-                newArrayList("CURRENT_DATE", "SYSDATE"), "NOW"));
+                newArrayList("CURRENT_DATE", "SYSDATE"), "NOW()"));
 
         addTranslator(new CurrentTimestampTranslator(DB2,
-                newArrayList("CURRENT DATE", "CURRENT TIME", "CURRENT TIMESTAMP"), "NOW"));
+                newArrayList("CURRENT DATE", "CURRENT TIME", "CURRENT TIMESTAMP"), "NOW()"));
     }
 
     @Override

--- a/core/src/test/java/com/nuodb/migrator/integration/types/Db2Types.java
+++ b/core/src/test/java/com/nuodb/migrator/integration/types/Db2Types.java
@@ -198,7 +198,7 @@ public class Db2Types implements DatabaseTypes {
                                 || "INT".equalsIgnoreCase(type)) {
                         return defaultValue == null ? null : "'" + defaultValue + "'";
                 } else if ("TIMESTAMP".equalsIgnoreCase(type)) {
-                        return "CURRENT_TIMESTAMP".equals(defaultValue) ? "'NOW()'"
+                        return "CURRENT_TIMESTAMP".equals(defaultValue) ? "NOW()"
                                         : defaultValue;
                 }
                 return defaultValue;

--- a/core/src/test/java/com/nuodb/migrator/integration/types/Db2Types.java
+++ b/core/src/test/java/com/nuodb/migrator/integration/types/Db2Types.java
@@ -35,176 +35,176 @@ import java.util.Map;
  * @author Krishnamoorthy Dhandapani
  */
 public class Db2Types implements DatabaseTypes {
-	private static Map<String, JDBCGetMethod[]> map = new HashMap<String, JDBCGetMethod[]>();
+        private static Map<String, JDBCGetMethod[]> map = new HashMap<String, JDBCGetMethod[]>();
 
-	static {
-		map.put("BOOLEAN", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
-		map.put("GRAPHIC", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("VARCHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("LONG VARCHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("LONG VARGRAPHIC", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("CHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("VARGRAPHIC", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("INTEGER", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT });
-		map.put("SMALLINT", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT });
-		map.put("MEDIUMINT", new JDBCGetMethod[] { JDBCGetMethod.INT,
-				JDBCGetMethod.LONG });
-		map.put("BIGINT", new JDBCGetMethod[] { JDBCGetMethod.INT,
-				JDBCGetMethod.LONG });
-		map.put("REAL", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
-		map.put("FLOAT", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
-		map.put("DOUBLE", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
-		map.put("DECIMAL", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+        static {
+                map.put("BOOLEAN", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
+                map.put("GRAPHIC", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("VARCHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("LONG VARCHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("LONG VARGRAPHIC", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("CHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("VARGRAPHIC", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("INTEGER", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT });
+                map.put("SMALLINT", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT });
+                map.put("MEDIUMINT", new JDBCGetMethod[] { JDBCGetMethod.INT,
+                                JDBCGetMethod.LONG });
+                map.put("BIGINT", new JDBCGetMethod[] { JDBCGetMethod.INT,
+                                JDBCGetMethod.LONG });
+                map.put("REAL", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
+                map.put("FLOAT", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
+                map.put("DOUBLE", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
+                map.put("DECIMAL", new JDBCGetMethod[] { JDBCGetMethod.STRING });
 
-		map.put("DATE", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIMESTAMP });
-		map.put("TIMESTAMP", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIMESTAMP });
-		map.put("CLOB", new JDBCGetMethod[] { JDBCGetMethod.CLOB });
-		map.put("DBCLOB", new JDBCGetMethod[] { JDBCGetMethod.CLOB });
+                map.put("DATE", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIMESTAMP });
+                map.put("TIMESTAMP", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIMESTAMP });
+                map.put("CLOB", new JDBCGetMethod[] { JDBCGetMethod.CLOB });
+                map.put("DBCLOB", new JDBCGetMethod[] { JDBCGetMethod.CLOB });
 
-		map.put("TIME", new JDBCGetMethod[] { JDBCGetMethod.TIME,
-				JDBCGetMethod.TIMESTAMP });
-		map.put("BLOB", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
-		map.put("XML", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-	}
+                map.put("TIME", new JDBCGetMethod[] { JDBCGetMethod.TIME,
+                                JDBCGetMethod.TIMESTAMP });
+                map.put("BLOB", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
+                map.put("XML", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+        }
 
-	public JDBCGetMethod[] getJDBCTypes(String type) {
-		return map.get(type);
-	}
+        public JDBCGetMethod[] getJDBCTypes(String type) {
+                return map.get(type);
+        }
 
-	public static int getKeyType(String type) {
-		if ("PRI".equals(type)) {
-			return 0;
-		} else if ("UNI".equals(type)) {
-			return 1;
-		}
-		return -1;
-	}
+        public static int getKeyType(String type) {
+                if ("PRI".equals(type)) {
+                        return 0;
+                } else if ("UNI".equals(type)) {
+                        return 1;
+                }
+                return -1;
+        }
 
-	public static int getMappedJDBCType(String type, String length) {
-		if ("VARCHAR".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("LONG VARCHAR".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("VARGRAPHIC".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("LONG VARGRAPHIC".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("DATE".equalsIgnoreCase(type)) {
-			return Types.DATE;
-		} else if ("SMALLINT".equalsIgnoreCase(type)) {
-			return Types.SMALLINT;
-		} else if ("INTEGER".equalsIgnoreCase(type)) {
-			return Types.INTEGER;
-		} else if ("FLOAT".equalsIgnoreCase(type)) {
-			return Types.FLOAT;
-		} else if ("REAL".equalsIgnoreCase(type)) {
-			return Types.FLOAT;
-		} else if ("BIGINT".equalsIgnoreCase(type)) {
-			return Types.BIGINT;
-		} else if ("DOUBLE".equalsIgnoreCase(type)) {
-			return Types.DOUBLE;
-		} else if ("DECIMAL".equalsIgnoreCase(type)) {
-			if ("31".equalsIgnoreCase(length)) {
-				return Types.NUMERIC;
-			}
-			return Types.INTEGER;
-		} else if ("TIMESTAMP".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		} else if ("CLOB".equalsIgnoreCase(type)) {
-			return Types.CLOB;
-		} else if ("DBCLOB".equalsIgnoreCase(type)) {
-			return Types.CLOB;
-		} else if ("TIME".equalsIgnoreCase(type)) {
-			return Types.TIME;
-		} else if ("GRAPHIC".equalsIgnoreCase(type)) {
-			return Types.CHAR;
-		} else if ("CHARACTER".equalsIgnoreCase(type)) {
-			return Types.CHAR;
-		} else if ("BLOB".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		} else if ("XML".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		}
-		return 0;
-	}
+        public static int getMappedJDBCType(String type, String length) {
+                if ("VARCHAR".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("LONG VARCHAR".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("VARGRAPHIC".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("LONG VARGRAPHIC".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("DATE".equalsIgnoreCase(type)) {
+                        return Types.DATE;
+                } else if ("SMALLINT".equalsIgnoreCase(type)) {
+                        return Types.SMALLINT;
+                } else if ("INTEGER".equalsIgnoreCase(type)) {
+                        return Types.INTEGER;
+                } else if ("FLOAT".equalsIgnoreCase(type)) {
+                        return Types.FLOAT;
+                } else if ("REAL".equalsIgnoreCase(type)) {
+                        return Types.FLOAT;
+                } else if ("BIGINT".equalsIgnoreCase(type)) {
+                        return Types.BIGINT;
+                } else if ("DOUBLE".equalsIgnoreCase(type)) {
+                        return Types.DOUBLE;
+                } else if ("DECIMAL".equalsIgnoreCase(type)) {
+                        if ("31".equalsIgnoreCase(length)) {
+                                return Types.NUMERIC;
+                        }
+                        return Types.INTEGER;
+                } else if ("TIMESTAMP".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                } else if ("CLOB".equalsIgnoreCase(type)) {
+                        return Types.CLOB;
+                } else if ("DBCLOB".equalsIgnoreCase(type)) {
+                        return Types.CLOB;
+                } else if ("TIME".equalsIgnoreCase(type)) {
+                        return Types.TIME;
+                } else if ("GRAPHIC".equalsIgnoreCase(type)) {
+                        return Types.CHAR;
+                } else if ("CHARACTER".equalsIgnoreCase(type)) {
+                        return Types.CHAR;
+                } else if ("BLOB".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                } else if ("XML".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                }
+                return 0;
+        }
 
-	public static String getMappedLength(String type, String length) {
-		if ("VARCHAR".equalsIgnoreCase(type)) {
-			return length;
-		} else if ("GRAPHIC".equalsIgnoreCase(type)) {
-			if ("68".equalsIgnoreCase(length)) {
-				return "136";
-			}
-			return "40";
-		} else if ("VARGRAPHIC".equalsIgnoreCase(type)) {
-			if ("16292".equalsIgnoreCase(length)) {
-				return "32584";
-			}
-			return "40";
-		} else if ("DATE".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("SMALLINT".equalsIgnoreCase(type)) {
-			return "2";
-		} else if ("CHARACTER".equalsIgnoreCase(type)) {
-			if ("20".equalsIgnoreCase(length)) {
-				return "20";
-			}
-			return "195";
-		} else if ("INTEGER".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("FLOAT".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("REAL".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("DOUBLE".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("BIGINT".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("DECIMAL".equalsIgnoreCase(type)) {
-			if ("31".equalsIgnoreCase(length)) {
-				return "32";
-			}
-			return "4";
-		} else if ("CLOB".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("DBCLOB".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("TIMESTAMP".equalsIgnoreCase(type)) {
-			return "12";
-		} else if ("CHAR".equalsIgnoreCase(type)) {
-			return "20";
-		} else if ("TIME".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("LONG VARCHAR".equalsIgnoreCase(type)) {
-			return "32700";
-		} else if ("LONG VARGRAPHIC".equalsIgnoreCase(type)) {
-			return "32700";
-		} else if ("BLOB".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("XML".equalsIgnoreCase(type)) {
-			return "100";
-		}
-		return null;
-	}
+        public static String getMappedLength(String type, String length) {
+                if ("VARCHAR".equalsIgnoreCase(type)) {
+                        return length;
+                } else if ("GRAPHIC".equalsIgnoreCase(type)) {
+                        if ("68".equalsIgnoreCase(length)) {
+                                return "136";
+                        }
+                        return "40";
+                } else if ("VARGRAPHIC".equalsIgnoreCase(type)) {
+                        if ("16292".equalsIgnoreCase(length)) {
+                                return "32584";
+                        }
+                        return "40";
+                } else if ("DATE".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("SMALLINT".equalsIgnoreCase(type)) {
+                        return "2";
+                } else if ("CHARACTER".equalsIgnoreCase(type)) {
+                        if ("20".equalsIgnoreCase(length)) {
+                                return "20";
+                        }
+                        return "195";
+                } else if ("INTEGER".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("FLOAT".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("REAL".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("DOUBLE".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("BIGINT".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("DECIMAL".equalsIgnoreCase(type)) {
+                        if ("31".equalsIgnoreCase(length)) {
+                                return "32";
+                        }
+                        return "4";
+                } else if ("CLOB".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("DBCLOB".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("TIMESTAMP".equalsIgnoreCase(type)) {
+                        return "12";
+                } else if ("CHAR".equalsIgnoreCase(type)) {
+                        return "20";
+                } else if ("TIME".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("LONG VARCHAR".equalsIgnoreCase(type)) {
+                        return "32700";
+                } else if ("LONG VARGRAPHIC".equalsIgnoreCase(type)) {
+                        return "32700";
+                } else if ("BLOB".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("XML".equalsIgnoreCase(type)) {
+                        return "100";
+                }
+                return null;
+        }
 
-	public static String getMappedDefault(String type, String defaultValue) {
-		if ("SMALLINT".equalsIgnoreCase(type)
-				|| "MEDIUMINT".equalsIgnoreCase(type)
-				|| "BIGINT".equalsIgnoreCase(type)
-				|| "INT".equalsIgnoreCase(type)) {
-			return defaultValue == null ? null : "'" + defaultValue + "'";
-		} else if ("TIMESTAMP".equalsIgnoreCase(type)) {
-			return "CURRENT_TIMESTAMP".equals(defaultValue) ? "'NOW'"
-					: defaultValue;
-		}
-		return defaultValue;
-	}
+        public static String getMappedDefault(String type, String defaultValue) {
+                if ("SMALLINT".equalsIgnoreCase(type)
+                                || "MEDIUMINT".equalsIgnoreCase(type)
+                                || "BIGINT".equalsIgnoreCase(type)
+                                || "INT".equalsIgnoreCase(type)) {
+                        return defaultValue == null ? null : "'" + defaultValue + "'";
+                } else if ("TIMESTAMP".equalsIgnoreCase(type)) {
+                        return "CURRENT_TIMESTAMP".equals(defaultValue) ? "'NOW()'"
+                                        : defaultValue;
+                }
+                return defaultValue;
+        }
 
-	public boolean isCaseSensitive() {
-		return false;
-	}
+        public boolean isCaseSensitive() {
+                return false;
+        }
 }

--- a/core/src/test/java/com/nuodb/migrator/integration/types/MySQLTypes.java
+++ b/core/src/test/java/com/nuodb/migrator/integration/types/MySQLTypes.java
@@ -308,7 +308,7 @@ public class MySQLTypes implements DatabaseTypes {
                         if ("0000-00-00 00:00:00".equals(defaultValue)) {
                                 return "'0000-00-00 00:00:00'";
                         }
-                        return "CURRENT_TIMESTAMP".equals(defaultValue) ? "'NOW()'" : "'"
+                        return "CURRENT_TIMESTAMP".equals(defaultValue) ? "NOW()" : "'"
                                         + defaultValue + "'";
                 } else if ("char".equalsIgnoreCase(type)) {
                         return defaultValue == null ? null : "'" + defaultValue + "'";

--- a/core/src/test/java/com/nuodb/migrator/integration/types/MySQLTypes.java
+++ b/core/src/test/java/com/nuodb/migrator/integration/types/MySQLTypes.java
@@ -35,243 +35,243 @@ import java.util.Map;
  * @author Krishnamoorthy Dhandapani
  */
 public class MySQLTypes implements DatabaseTypes {
-	private static Map<String, JDBCGetMethod[]> map = new HashMap<String, JDBCGetMethod[]>();
+        private static Map<String, JDBCGetMethod[]> map = new HashMap<String, JDBCGetMethod[]>();
 
-	static {
-		map.put("BOOL", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
-		map.put("BOOLEAN", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
+        static {
+                map.put("BOOL", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
+                map.put("BOOLEAN", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
 
-		map.put("LONG", new JDBCGetMethod[] { JDBCGetMethod.LONG });
+                map.put("LONG", new JDBCGetMethod[] { JDBCGetMethod.LONG });
 
-		map.put("VARCHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("VARCHAR2", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("TEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("TINYTEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("MEDIUMTEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("LONGTEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("CHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("VARCHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("VARCHAR2", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("TEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("TINYTEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("MEDIUMTEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("LONGTEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("CHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
 
-		map.put("INT", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT, JDBCGetMethod.LONG });
-		map.put("INT UNSIGNED", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT, JDBCGetMethod.LONG }); // INT UNSIGNED
-		map.put("BIT", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
-		map.put("TINYINT", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT });
-		map.put("TINYINT UNSIGNED", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT }); // TINYINT UNSIGNED
-		map.put("SMALLINT", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT });
-		map.put("SMALLINT UNSIGNED", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT }); // SMALLINT UNSIGNED
-		map.put("MEDIUMINT", new JDBCGetMethod[] { JDBCGetMethod.INT,
-				JDBCGetMethod.LONG });
-		map.put("MEDIUMINT UNSIGNED", new JDBCGetMethod[] { JDBCGetMethod.INT,
-				JDBCGetMethod.LONG }); // MEDIUMINT UNSIGNED
-		map.put("BIGINT", new JDBCGetMethod[] { JDBCGetMethod.INT,
-				JDBCGetMethod.LONG });
-		map.put("BIGINT UNSIGNED", new JDBCGetMethod[] { JDBCGetMethod.INT,
-				JDBCGetMethod.LONG, JDBCGetMethod.BIGDECIMAL });
-		map.put("FLOAT", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
-		map.put("FLOAT UNSIGNED", new JDBCGetMethod[] { JDBCGetMethod.FLOAT }); // FLOAT
-																				// UNSIGNED
-		map.put("DOUBLE UNSIGNED", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE }); // DOUBLE
-																					// UNSIGNED
-		map.put("DOUBLE", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
-		// TODO: revert back to double after bug fix
-		// JDBCType.DOUBLE });
-		map.put("DECIMAL", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("DECIMAL UNSIGNED",
-				new JDBCGetMethod[] { JDBCGetMethod.STRING }); // DECIMAL
-																// UNSIGNED
-		map.put("DATE", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIMESTAMP });
-		map.put("DATETIME", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIMESTAMP });
-		map.put("TIMESTAMP", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIMESTAMP });
-		map.put("TIME", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIME, JDBCGetMethod.TIMESTAMP });
-		map.put("YEAR", new JDBCGetMethod[] { JDBCGetMethod.SHORT });
+                map.put("INT", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT, JDBCGetMethod.LONG });
+                map.put("INT UNSIGNED", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT, JDBCGetMethod.LONG }); // INT UNSIGNED
+                map.put("BIT", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
+                map.put("TINYINT", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT });
+                map.put("TINYINT UNSIGNED", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT }); // TINYINT UNSIGNED
+                map.put("SMALLINT", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT });
+                map.put("SMALLINT UNSIGNED", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT }); // SMALLINT UNSIGNED
+                map.put("MEDIUMINT", new JDBCGetMethod[] { JDBCGetMethod.INT,
+                                JDBCGetMethod.LONG });
+                map.put("MEDIUMINT UNSIGNED", new JDBCGetMethod[] { JDBCGetMethod.INT,
+                                JDBCGetMethod.LONG }); // MEDIUMINT UNSIGNED
+                map.put("BIGINT", new JDBCGetMethod[] { JDBCGetMethod.INT,
+                                JDBCGetMethod.LONG });
+                map.put("BIGINT UNSIGNED", new JDBCGetMethod[] { JDBCGetMethod.INT,
+                                JDBCGetMethod.LONG, JDBCGetMethod.BIGDECIMAL });
+                map.put("FLOAT", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
+                map.put("FLOAT UNSIGNED", new JDBCGetMethod[] { JDBCGetMethod.FLOAT }); // FLOAT
+                                                                                                                                                                // UNSIGNED
+                map.put("DOUBLE UNSIGNED", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE }); // DOUBLE
+                                                                                                                                                                        // UNSIGNED
+                map.put("DOUBLE", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
+                // TODO: revert back to double after bug fix
+                // JDBCType.DOUBLE });
+                map.put("DECIMAL", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("DECIMAL UNSIGNED",
+                                new JDBCGetMethod[] { JDBCGetMethod.STRING }); // DECIMAL
+                                                                                                                                // UNSIGNED
+                map.put("DATE", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIMESTAMP });
+                map.put("DATETIME", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIMESTAMP });
+                map.put("TIMESTAMP", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIMESTAMP });
+                map.put("TIME", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIME, JDBCGetMethod.TIMESTAMP });
+                map.put("YEAR", new JDBCGetMethod[] { JDBCGetMethod.SHORT });
 
-		map.put("BLOB", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
-		map.put("TINYBLOB", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
-		map.put("MEDIUMBLOB", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
-		map.put("LONGBLOB", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
-		map.put("BINARY", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
-		map.put("VARBINARY", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
-	}
+                map.put("BLOB", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
+                map.put("TINYBLOB", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
+                map.put("MEDIUMBLOB", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
+                map.put("LONGBLOB", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
+                map.put("BINARY", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
+                map.put("VARBINARY", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
+        }
 
-	public JDBCGetMethod[] getJDBCTypes(String type) {
-		return map.get(type);
-	}
+        public JDBCGetMethod[] getJDBCTypes(String type) {
+                return map.get(type);
+        }
 
-	public static int getKeyType(String type) {
-		if ("PRI".equals(type)) {
-			return 0;
-		} else if ("UNI".equals(type)) {
-			return 1;
-		}
-		return -1;
-	}
+        public static int getKeyType(String type) {
+                if ("PRI".equals(type)) {
+                        return 0;
+                } else if ("UNI".equals(type)) {
+                        return 1;
+                }
+                return -1;
+        }
 
-	public static int getMappedJDBCType(String type, String colType) {
-		if ("VARCHAR".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("VARCHAR2".equalsIgnoreCase(type)) {
-			return Types.NVARCHAR;
-		} else if ("TINYINT".equalsIgnoreCase(type)) {
-			return Types.SMALLINT;
-		} else if ("TEXT".equalsIgnoreCase(type)) {
-			return Types.CLOB;
-		} else if ("DATE".equalsIgnoreCase(type)) {
-			return Types.DATE;
-		} else if ("SMALLINT".equalsIgnoreCase(type)) {
-			if (colType != null && colType.toLowerCase().contains("unsigned")) {
-				return Types.INTEGER;
-			} else {
-				return Types.SMALLINT;
-			}
-		} else if ("MEDIUMINT".equalsIgnoreCase(type)) {
-			return Types.INTEGER;
-		} else if ("BIGINT".equalsIgnoreCase(type)) {
-			if (colType != null && colType.toLowerCase().contains("unsigned")) {
-				return Types.NUMERIC;
-			} else {
-				return Types.BIGINT;
-			}
-		} else if ("INT".equalsIgnoreCase(type)) {
-			if (colType != null && colType.toLowerCase().contains("unsigned")) {
-				return Types.BIGINT;
-			} else {
-				return Types.INTEGER;
-			}
-		} else if ("FLOAT".equalsIgnoreCase(type)) {
-			return Types.DOUBLE; // in NuoDB, float is double internally
-		} else if ("DOUBLE".equalsIgnoreCase(type)) {
-			return Types.DOUBLE;
-		} else if ("DECIMAL".equalsIgnoreCase(type)) {
-			if (colType != null && colType.equalsIgnoreCase("decimal(6,2)")) {
-				return Types.INTEGER;
-			} else if (colType != null && colType.contains("decimal(65,30)")) {
-				return Types.NUMERIC;
-			} else {
-				return Types.BIGINT;
-			}
-		} else if ("DATETIME".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		} else if ("TIMESTAMP".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		} else if ("YEAR".equalsIgnoreCase(type)) {
-			return Types.SMALLINT;
-		} else if ("CHAR".equalsIgnoreCase(type)) {
-			return Types.CHAR;
-		} else if ("TINYTEXT".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("BLOB".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		} else if ("MEDIUMBLOB".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		} else if ("LONGBLOB".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		} else if ("VARBINARY".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		} else if ("BINARY".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		} else if ("MEDIUMTEXT".equalsIgnoreCase(type)) {
-			return Types.CLOB;
-		} else if ("LONGTEXT".equalsIgnoreCase(type)) {
-			return Types.CLOB;
-		} else if ("BIT".equalsIgnoreCase(type)) {
-			return Types.BOOLEAN;
-		} else if ("TINYBLOB".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		} else if ("ENUM".equalsIgnoreCase(type)) {
-			return Types.SMALLINT;
-		} else if ("SET".equalsIgnoreCase(type)) {
-			return Types.CHAR;
-		} else if ("TIME".equalsIgnoreCase(type)) {
-			return Types.TIME;
-		}
+        public static int getMappedJDBCType(String type, String colType) {
+                if ("VARCHAR".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("VARCHAR2".equalsIgnoreCase(type)) {
+                        return Types.NVARCHAR;
+                } else if ("TINYINT".equalsIgnoreCase(type)) {
+                        return Types.SMALLINT;
+                } else if ("TEXT".equalsIgnoreCase(type)) {
+                        return Types.CLOB;
+                } else if ("DATE".equalsIgnoreCase(type)) {
+                        return Types.DATE;
+                } else if ("SMALLINT".equalsIgnoreCase(type)) {
+                        if (colType != null && colType.toLowerCase().contains("unsigned")) {
+                                return Types.INTEGER;
+                        } else {
+                                return Types.SMALLINT;
+                        }
+                } else if ("MEDIUMINT".equalsIgnoreCase(type)) {
+                        return Types.INTEGER;
+                } else if ("BIGINT".equalsIgnoreCase(type)) {
+                        if (colType != null && colType.toLowerCase().contains("unsigned")) {
+                                return Types.NUMERIC;
+                        } else {
+                                return Types.BIGINT;
+                        }
+                } else if ("INT".equalsIgnoreCase(type)) {
+                        if (colType != null && colType.toLowerCase().contains("unsigned")) {
+                                return Types.BIGINT;
+                        } else {
+                                return Types.INTEGER;
+                        }
+                } else if ("FLOAT".equalsIgnoreCase(type)) {
+                        return Types.DOUBLE; // in NuoDB, float is double internally
+                } else if ("DOUBLE".equalsIgnoreCase(type)) {
+                        return Types.DOUBLE;
+                } else if ("DECIMAL".equalsIgnoreCase(type)) {
+                        if (colType != null && colType.equalsIgnoreCase("decimal(6,2)")) {
+                                return Types.INTEGER;
+                        } else if (colType != null && colType.contains("decimal(65,30)")) {
+                                return Types.NUMERIC;
+                        } else {
+                                return Types.BIGINT;
+                        }
+                } else if ("DATETIME".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                } else if ("TIMESTAMP".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                } else if ("YEAR".equalsIgnoreCase(type)) {
+                        return Types.SMALLINT;
+                } else if ("CHAR".equalsIgnoreCase(type)) {
+                        return Types.CHAR;
+                } else if ("TINYTEXT".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("BLOB".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                } else if ("MEDIUMBLOB".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                } else if ("LONGBLOB".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                } else if ("VARBINARY".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                } else if ("BINARY".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                } else if ("MEDIUMTEXT".equalsIgnoreCase(type)) {
+                        return Types.CLOB;
+                } else if ("LONGTEXT".equalsIgnoreCase(type)) {
+                        return Types.CLOB;
+                } else if ("BIT".equalsIgnoreCase(type)) {
+                        return Types.BOOLEAN;
+                } else if ("TINYBLOB".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                } else if ("ENUM".equalsIgnoreCase(type)) {
+                        return Types.SMALLINT;
+                } else if ("SET".equalsIgnoreCase(type)) {
+                        return Types.CHAR;
+                } else if ("TIME".equalsIgnoreCase(type)) {
+                        return Types.TIME;
+                }
 
-		return 0;
-	}
+                return 0;
+        }
 
-	public static String getMappedLength(String type, String colType,
-			String length) {
-		if ("VARCHAR".equalsIgnoreCase(type)) {
-			return length;
-		} else if ("VARCHAR2".equalsIgnoreCase(type)) {
-			return length;
-		} else if ("TINYINT".equalsIgnoreCase(type)) {
-			return "2";
-		} else if ("TEXT".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("DATE".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("SMALLINT".equalsIgnoreCase(type)) {
-			if (colType != null && colType.toLowerCase().contains("unsigned")) {
-				return "4";
-			} else {
-				return "2";
-			}
-		} else if ("MEDIUMINT".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("BIGINT".equalsIgnoreCase(type)) {
-			if (colType != null && colType.toLowerCase().contains("unsigned")) {
-				return "32";
-			} else {
-				return "8";
-			}
-		} else if ("INT".equalsIgnoreCase(type)) {
-			if (colType != null && colType.toLowerCase().contains("unsigned")) {
-				return "8";
-			} else {
-				return "4";
-			}
-		} else if ("FLOAT".equalsIgnoreCase(type)) {
-			return "8"; // in NuoDB, float is double internally
-		} else if ("DOUBLE".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("DECIMAL".equalsIgnoreCase(type)) {
-			if (colType != null && colType.equalsIgnoreCase("decimal(6,2)")) {
-				return "4";
-			} else if (colType != null && colType.contains("decimal(65,30)")) {
-				return "32";
-			} else {
-				return "8";
-			}
-		} else if ("DATETIME".equalsIgnoreCase(type)) {
-			return "12";
-		} else if ("TIME".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("TIMESTAMP".equalsIgnoreCase(type)) {
-			return "12";
-		} else if ("YEAR".equalsIgnoreCase(type)) {
-			return "2";
-		} else if ("CHAR".equalsIgnoreCase(type)) {
-			return length;
-		} else if ("TINYTEXT".equalsIgnoreCase(type)) {
-			return "255";
-		} else if ("BLOB".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("MEDIUMBLOB".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("LONGBLOB".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("MEDIUMTEXT".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("LONGTEXT".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("BIT".equalsIgnoreCase(type)) {
-			return "2";
-		} else if ("VARBINARY".equalsIgnoreCase(type)) {
-			return "90";
-		} else if ("BINARY".equalsIgnoreCase(type)) {
-			return "90";
-		} else if ("TINYBLOB".equalsIgnoreCase(type)) {
-			return "255";
-		} else if ("ENUM".equalsIgnoreCase(type)) {
+        public static String getMappedLength(String type, String colType,
+                        String length) {
+                if ("VARCHAR".equalsIgnoreCase(type)) {
+                        return length;
+                } else if ("VARCHAR2".equalsIgnoreCase(type)) {
+                        return length;
+                } else if ("TINYINT".equalsIgnoreCase(type)) {
+                        return "2";
+                } else if ("TEXT".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("DATE".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("SMALLINT".equalsIgnoreCase(type)) {
+                        if (colType != null && colType.toLowerCase().contains("unsigned")) {
+                                return "4";
+                        } else {
+                                return "2";
+                        }
+                } else if ("MEDIUMINT".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("BIGINT".equalsIgnoreCase(type)) {
+                        if (colType != null && colType.toLowerCase().contains("unsigned")) {
+                                return "32";
+                        } else {
+                                return "8";
+                        }
+                } else if ("INT".equalsIgnoreCase(type)) {
+                        if (colType != null && colType.toLowerCase().contains("unsigned")) {
+                                return "8";
+                        } else {
+                                return "4";
+                        }
+                } else if ("FLOAT".equalsIgnoreCase(type)) {
+                        return "8"; // in NuoDB, float is double internally
+                } else if ("DOUBLE".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("DECIMAL".equalsIgnoreCase(type)) {
+                        if (colType != null && colType.equalsIgnoreCase("decimal(6,2)")) {
+                                return "4";
+                        } else if (colType != null && colType.contains("decimal(65,30)")) {
+                                return "32";
+                        } else {
+                                return "8";
+                        }
+                } else if ("DATETIME".equalsIgnoreCase(type)) {
+                        return "12";
+                } else if ("TIME".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("TIMESTAMP".equalsIgnoreCase(type)) {
+                        return "12";
+                } else if ("YEAR".equalsIgnoreCase(type)) {
+                        return "2";
+                } else if ("CHAR".equalsIgnoreCase(type)) {
+                        return length;
+                } else if ("TINYTEXT".equalsIgnoreCase(type)) {
+                        return "255";
+                } else if ("BLOB".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("MEDIUMBLOB".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("LONGBLOB".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("MEDIUMTEXT".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("LONGTEXT".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("BIT".equalsIgnoreCase(type)) {
+                        return "2";
+                } else if ("VARBINARY".equalsIgnoreCase(type)) {
+                        return "90";
+                } else if ("BINARY".equalsIgnoreCase(type)) {
+                        return "90";
+                } else if ("TINYBLOB".equalsIgnoreCase(type)) {
+                        return "255";
+                } else if ("ENUM".equalsIgnoreCase(type)) {
             // TODO: temporary fix NuoDB ENUM length issue
             // How to reproduce the issue:
             // CREATE TABLE TEST.T1 (F1 ENUM('123', '12345'));
@@ -281,50 +281,50 @@ public class MySQLTypes implements DatabaseTypes {
             // Expected result:
             // 5=max('123'.length(), '12345'.length());
             return "2";
-		} else if ("SET".equalsIgnoreCase(type)) {
-			if (length != null && length.equalsIgnoreCase("22")) {
-				return "22";
-			} else if (length != null && length.equalsIgnoreCase("19")) {
-				return "19";
-			} else if (length != null && length.equalsIgnoreCase("24")) {
-				return "26";
-			} else if (length != null && length.equalsIgnoreCase("21")) {
-				return "21";
-			} else {
-				return "14";
-			}
-		}
-		return null;
-	}
+                } else if ("SET".equalsIgnoreCase(type)) {
+                        if (length != null && length.equalsIgnoreCase("22")) {
+                                return "22";
+                        } else if (length != null && length.equalsIgnoreCase("19")) {
+                                return "19";
+                        } else if (length != null && length.equalsIgnoreCase("24")) {
+                                return "26";
+                        } else if (length != null && length.equalsIgnoreCase("21")) {
+                                return "21";
+                        } else {
+                                return "14";
+                        }
+                }
+                return null;
+        }
 
-	public static String getMappedDefault(String type, String defaultValue) {
-		if ("SMALLINT".equalsIgnoreCase(type)
-				|| "MEDIUMINT".equalsIgnoreCase(type)
-				|| "BIGINT".equalsIgnoreCase(type)
-				|| "INT".equalsIgnoreCase(type)
-				|| "TINYINT".equalsIgnoreCase(type)) {
-			return defaultValue == null ? null : "'" + defaultValue + "'";
-		} else if ("TIMESTAMP".equalsIgnoreCase(type)) {
-			if ("0000-00-00 00:00:00".equals(defaultValue)) {
-				return "'0000-00-00 00:00:00'";
-			}
-			return "CURRENT_TIMESTAMP".equals(defaultValue) ? "'NOW'" : "'"
-					+ defaultValue + "'";
-		} else if ("char".equalsIgnoreCase(type)) {
-			return defaultValue == null ? null : "'" + defaultValue + "'";
-		} else if ("datetime".equalsIgnoreCase(type)) {
-			return defaultValue == null ? null : "'" + defaultValue + "'";
-		} else if ("timestamp".equalsIgnoreCase(type)) {
-			return defaultValue == null ? null : "'" + defaultValue + "'";
-		} else if ("varchar".equalsIgnoreCase(type)) {
-			return defaultValue == null ? null : "'" + defaultValue + "'";
-		} else if ("year".equalsIgnoreCase(type)) {
-			return defaultValue == null ? null : "'" + defaultValue + "'";
-		}
-		return defaultValue;
-	}
+        public static String getMappedDefault(String type, String defaultValue) {
+                if ("SMALLINT".equalsIgnoreCase(type)
+                                || "MEDIUMINT".equalsIgnoreCase(type)
+                                || "BIGINT".equalsIgnoreCase(type)
+                                || "INT".equalsIgnoreCase(type)
+                                || "TINYINT".equalsIgnoreCase(type)) {
+                        return defaultValue == null ? null : "'" + defaultValue + "'";
+                } else if ("TIMESTAMP".equalsIgnoreCase(type)) {
+                        if ("0000-00-00 00:00:00".equals(defaultValue)) {
+                                return "'0000-00-00 00:00:00'";
+                        }
+                        return "CURRENT_TIMESTAMP".equals(defaultValue) ? "'NOW()'" : "'"
+                                        + defaultValue + "'";
+                } else if ("char".equalsIgnoreCase(type)) {
+                        return defaultValue == null ? null : "'" + defaultValue + "'";
+                } else if ("datetime".equalsIgnoreCase(type)) {
+                        return defaultValue == null ? null : "'" + defaultValue + "'";
+                } else if ("timestamp".equalsIgnoreCase(type)) {
+                        return defaultValue == null ? null : "'" + defaultValue + "'";
+                } else if ("varchar".equalsIgnoreCase(type)) {
+                        return defaultValue == null ? null : "'" + defaultValue + "'";
+                } else if ("year".equalsIgnoreCase(type)) {
+                        return defaultValue == null ? null : "'" + defaultValue + "'";
+                }
+                return defaultValue;
+        }
 
-	public boolean isCaseSensitive() {
-		return false;
-	}
+        public boolean isCaseSensitive() {
+                return false;
+        }
 }

--- a/core/src/test/java/com/nuodb/migrator/integration/types/NuoDBTypes.java
+++ b/core/src/test/java/com/nuodb/migrator/integration/types/NuoDBTypes.java
@@ -35,127 +35,127 @@ import java.util.Map;
  * @author Krishnamoorthy Dhandapani
  */
 public class NuoDBTypes implements DatabaseTypes {
-	private static Map<String, JDBCGetMethod[]> map = new HashMap<String, JDBCGetMethod[]>();
+        private static Map<String, JDBCGetMethod[]> map = new HashMap<String, JDBCGetMethod[]>();
 
-	static {
-		map.put("BOOLEAN", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
+        static {
+                map.put("BOOLEAN", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
 
-		map.put("BIGINT", new JDBCGetMethod[] { JDBCGetMethod.LONG });
+                map.put("BIGINT", new JDBCGetMethod[] { JDBCGetMethod.LONG });
 
-		map.put("VARCHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("STRING", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("CHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("VARCHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("STRING", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("CHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
 
-		map.put("INTEGER", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT });
-		map.put("NUMBER", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT });
-		map.put("SMALLINT", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT, JDBCGetMethod.STRING });
-		map.put("BIGINT", new JDBCGetMethod[] { JDBCGetMethod.INT,
-				JDBCGetMethod.LONG });
+                map.put("INTEGER", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT });
+                map.put("NUMBER", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT });
+                map.put("SMALLINT", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT, JDBCGetMethod.STRING });
+                map.put("BIGINT", new JDBCGetMethod[] { JDBCGetMethod.INT,
+                                JDBCGetMethod.LONG });
 
-		map.put("FLOAT", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
-		map.put("DOUBLE", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
+                map.put("FLOAT", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
+                map.put("DOUBLE", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
 
-		map.put("DATE", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIMESTAMP });
-		map.put("TIMESTAMP", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIMESTAMP });
-		map.put("TIME", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIME, JDBCGetMethod.TIMESTAMP });
+                map.put("DATE", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIMESTAMP });
+                map.put("TIMESTAMP", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIMESTAMP });
+                map.put("TIME", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIME, JDBCGetMethod.TIMESTAMP });
 
-		map.put("BINARYSTRING", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
-		map.put("BINARYVARYINGSTRING",
-				new JDBCGetMethod[] { JDBCGetMethod.BLOB });
+                map.put("BINARYSTRING", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
+                map.put("BINARYVARYINGSTRING",
+                                new JDBCGetMethod[] { JDBCGetMethod.BLOB });
 
-		map.put("BLOB", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
-		map.put("CLOB", new JDBCGetMethod[] { JDBCGetMethod.CLOB });
-		// map.put("NUMERIC", new JDBCGetMethod[]{JDBCGetMethod.STRING});
-	}
+                map.put("BLOB", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
+                map.put("CLOB", new JDBCGetMethod[] { JDBCGetMethod.CLOB });
+                // map.put("NUMERIC", new JDBCGetMethod[]{JDBCGetMethod.STRING});
+        }
 
-	public JDBCGetMethod[] getJDBCTypes(String type) {
-		return map.get(type.toUpperCase());
-	}
+        public JDBCGetMethod[] getJDBCTypes(String type) {
+                return map.get(type.toUpperCase());
+        }
 
-	public static int getKeyType(String type) {
-		if ("PRI".equals(type)) {
-			return 0;
-		} else if ("UNI".equals(type)) {
-			return 1;
-		}
-		return -1;
-	}
+        public static int getKeyType(String type) {
+                if ("PRI".equals(type)) {
+                        return 0;
+                } else if ("UNI".equals(type)) {
+                        return 1;
+                }
+                return -1;
+        }
 
-	public static int getMappedJDBCType(String type) {
-		if ("VARCHAR".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("CLOB".equalsIgnoreCase(type)) {
-			return Types.CLOB;
-		} else if ("DATE".equalsIgnoreCase(type)) {
-			return Types.DATE;
-		} else if ("SMALLINT".equalsIgnoreCase(type)) {
-			return Types.SMALLINT;
-		} else if ("BIGINT".equalsIgnoreCase(type)) {
-			return Types.BIGINT;
-		} else if ("INTEGER".equalsIgnoreCase(type)) {
-			return Types.INTEGER;
-		} else if ("FLOAT".equalsIgnoreCase(type)) {
-			return Types.FLOAT;
-		} else if ("DOUBLE".equalsIgnoreCase(type)) {
-			return Types.DOUBLE;
-		} else if ("TIMESTAMP".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		} else if ("TIME".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		} else if ("CHAR".equalsIgnoreCase(type)) {
-			return Types.CHAR;
-		} else if ("BLOB".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		}
-		return 0;
-	}
+        public static int getMappedJDBCType(String type) {
+                if ("VARCHAR".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("CLOB".equalsIgnoreCase(type)) {
+                        return Types.CLOB;
+                } else if ("DATE".equalsIgnoreCase(type)) {
+                        return Types.DATE;
+                } else if ("SMALLINT".equalsIgnoreCase(type)) {
+                        return Types.SMALLINT;
+                } else if ("BIGINT".equalsIgnoreCase(type)) {
+                        return Types.BIGINT;
+                } else if ("INTEGER".equalsIgnoreCase(type)) {
+                        return Types.INTEGER;
+                } else if ("FLOAT".equalsIgnoreCase(type)) {
+                        return Types.FLOAT;
+                } else if ("DOUBLE".equalsIgnoreCase(type)) {
+                        return Types.DOUBLE;
+                } else if ("TIMESTAMP".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                } else if ("TIME".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                } else if ("CHAR".equalsIgnoreCase(type)) {
+                        return Types.CHAR;
+                } else if ("BLOB".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                }
+                return 0;
+        }
 
-	public static String getMappedLength(String type, String length) {
-		if ("VARCHAR".equalsIgnoreCase(type)) {
-			return length;
-		} else if ("INTEGER".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("DATE".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("SMALLINT".equalsIgnoreCase(type)) {
-			return "2";
-		} else if ("BIGINT".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("FLOAT".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("DOUBLE".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("TIME".equalsIgnoreCase(type)) {
-			return "12";
-		} else if ("TIMESTAMP".equalsIgnoreCase(type)) {
-			return "12";
-		} else if ("CHAR".equalsIgnoreCase(type)) {
-			return "20";
-		} else if ("BLOB".equalsIgnoreCase(type)) {
-			return "8";
-		}
-		return null;
-	}
+        public static String getMappedLength(String type, String length) {
+                if ("VARCHAR".equalsIgnoreCase(type)) {
+                        return length;
+                } else if ("INTEGER".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("DATE".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("SMALLINT".equalsIgnoreCase(type)) {
+                        return "2";
+                } else if ("BIGINT".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("FLOAT".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("DOUBLE".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("TIME".equalsIgnoreCase(type)) {
+                        return "12";
+                } else if ("TIMESTAMP".equalsIgnoreCase(type)) {
+                        return "12";
+                } else if ("CHAR".equalsIgnoreCase(type)) {
+                        return "20";
+                } else if ("BLOB".equalsIgnoreCase(type)) {
+                        return "8";
+                }
+                return null;
+        }
 
-	public static String getMappedDefault(String type, String defaultValue) {
-		if ("SMALLINT".equalsIgnoreCase(type)
-				|| "BIGINT".equalsIgnoreCase(type)
-				|| "INTEGER".equalsIgnoreCase(type)) {
-			return defaultValue == null ? null : "'" + defaultValue + "'";
-		} else if ("TIMESTAMP".equalsIgnoreCase(type)) {
-			return "CURRENT_TIMESTAMP".equals(defaultValue) ? "'NOW'"
-					: defaultValue;
-		}
-		return defaultValue;
-	}
+        public static String getMappedDefault(String type, String defaultValue) {
+                if ("SMALLINT".equalsIgnoreCase(type)
+                                || "BIGINT".equalsIgnoreCase(type)
+                                || "INTEGER".equalsIgnoreCase(type)) {
+                        return defaultValue == null ? null : "'" + defaultValue + "'";
+                } else if ("TIMESTAMP".equalsIgnoreCase(type)) {
+                        return "CURRENT_TIMESTAMP".equals(defaultValue) ? "'NOW()'"
+                                        : defaultValue;
+                }
+                return defaultValue;
+        }
 
-	public boolean isCaseSensitive() {
-		return true;
-	}
+        public boolean isCaseSensitive() {
+                return true;
+        }
 }

--- a/core/src/test/java/com/nuodb/migrator/integration/types/NuoDBTypes.java
+++ b/core/src/test/java/com/nuodb/migrator/integration/types/NuoDBTypes.java
@@ -149,7 +149,7 @@ public class NuoDBTypes implements DatabaseTypes {
                                 || "INTEGER".equalsIgnoreCase(type)) {
                         return defaultValue == null ? null : "'" + defaultValue + "'";
                 } else if ("TIMESTAMP".equalsIgnoreCase(type)) {
-                        return "CURRENT_TIMESTAMP".equals(defaultValue) ? "'NOW()'"
+                        return "CURRENT_TIMESTAMP".equals(defaultValue) ? "NOW()"
                                         : defaultValue;
                 }
                 return defaultValue;

--- a/core/src/test/java/com/nuodb/migrator/integration/types/OracleTypes.java
+++ b/core/src/test/java/com/nuodb/migrator/integration/types/OracleTypes.java
@@ -302,7 +302,7 @@ public class OracleTypes implements DatabaseTypes {
                                 || "INT".equalsIgnoreCase(type)) {
                         return defaultValue == null ? null : "'" + defaultValue + "'";
                 } else if ("TIMESTAMP".equalsIgnoreCase(type)) {
-                        return "CURRENT_TIMESTAMP".equals(defaultValue) ? "'NOW()'"
+                        return "CURRENT_TIMESTAMP".equals(defaultValue) ? "NOW()"
                                         : defaultValue;
                 }
                 return defaultValue;

--- a/core/src/test/java/com/nuodb/migrator/integration/types/OracleTypes.java
+++ b/core/src/test/java/com/nuodb/migrator/integration/types/OracleTypes.java
@@ -35,280 +35,280 @@ import java.util.Map;
  * @author Krishnamoorthy Dhandapani
  */
 public class OracleTypes implements DatabaseTypes {
-	private static Map<String, JDBCGetMethod[]> map = new HashMap<String, JDBCGetMethod[]>();
+        private static Map<String, JDBCGetMethod[]> map = new HashMap<String, JDBCGetMethod[]>();
 
-	static {
-		map.put("BOOL", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
-		map.put("BOOLEAN", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
-		map.put("LONG", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+        static {
+                map.put("BOOL", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
+                map.put("BOOLEAN", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
+                map.put("LONG", new JDBCGetMethod[] { JDBCGetMethod.STRING });
 
-		map.put("VARCHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("VARCHAR2", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("NVARCHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("TEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("TINYTEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("MEDIUMTEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("LONGTEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("CHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("NCHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("NTEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("INT", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT });
-		map.put("NUMERIC", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT });
-		map.put("BINARY_FLOAT", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
-		map.put("BINARY_DOUBLE", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
-		map.put("NUMBER", new JDBCGetMethod[] { JDBCGetMethod.LONG,
-				JDBCGetMethod.BIGDECIMAL, JDBCGetMethod.STRING });
-		map.put("FLOAT", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
-		map.put("REAL", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
-		map.put("DOUBLE", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
+                map.put("VARCHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("VARCHAR2", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("NVARCHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("TEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("TINYTEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("MEDIUMTEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("LONGTEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("CHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("NCHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("NTEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("INT", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT });
+                map.put("NUMERIC", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT });
+                map.put("BINARY_FLOAT", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
+                map.put("BINARY_DOUBLE", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
+                map.put("NUMBER", new JDBCGetMethod[] { JDBCGetMethod.LONG,
+                                JDBCGetMethod.BIGDECIMAL, JDBCGetMethod.STRING });
+                map.put("FLOAT", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
+                map.put("REAL", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
+                map.put("DOUBLE", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
 
-		map.put("TIMESTAMPLTZ", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIMESTAMP, JDBCGetMethod.STRING });
-		// TODO: revert back to double after bug fix
-		// JDBCType.DOUBLE });
-		map.put("DECIMAL", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("TIMESTAMPLTZ", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIMESTAMP, JDBCGetMethod.STRING });
+                // TODO: revert back to double after bug fix
+                // JDBCType.DOUBLE });
+                map.put("DECIMAL", new JDBCGetMethod[] { JDBCGetMethod.STRING });
 
-		map.put("DATE", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIMESTAMP });
-		map.put("DATETIME", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIMESTAMP });
-		map.put("TIMESTAMP", new JDBCGetMethod[] { JDBCGetMethod.DATE });
-		map.put("TIMESTAMPTZ", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIMESTAMP });
-		map.put("TIME", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIME, JDBCGetMethod.TIMESTAMP });
-		map.put("BLOB", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
-		map.put("CLOB", new JDBCGetMethod[] { JDBCGetMethod.CLOB });
-		map.put("RAW", new JDBCGetMethod[] { JDBCGetMethod.BYTES });
-		map.put("TIMESTAMP WITH TIME ZONE", new JDBCGetMethod[] {
-				JDBCGetMethod.TIMESTAMP, });
-		map.put("TIMESTAMP WITH LOCAL TIME ZONE",
-				new JDBCGetMethod[] { JDBCGetMethod.TIMESTAMP });
-		map.put("NCLOB", new JDBCGetMethod[] { JDBCGetMethod.STRING,
-				JDBCGetMethod.CLOB });
-		map.put("NVARCHAR2", new JDBCGetMethod[] { JDBCGetMethod.BLOB,
-				JDBCGetMethod.STRING });
-		map.put("LONG RAW", new JDBCGetMethod[] { JDBCGetMethod.BYTES });
-	}
+                map.put("DATE", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIMESTAMP });
+                map.put("DATETIME", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIMESTAMP });
+                map.put("TIMESTAMP", new JDBCGetMethod[] { JDBCGetMethod.DATE });
+                map.put("TIMESTAMPTZ", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIMESTAMP });
+                map.put("TIME", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIME, JDBCGetMethod.TIMESTAMP });
+                map.put("BLOB", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
+                map.put("CLOB", new JDBCGetMethod[] { JDBCGetMethod.CLOB });
+                map.put("RAW", new JDBCGetMethod[] { JDBCGetMethod.BYTES });
+                map.put("TIMESTAMP WITH TIME ZONE", new JDBCGetMethod[] {
+                                JDBCGetMethod.TIMESTAMP, });
+                map.put("TIMESTAMP WITH LOCAL TIME ZONE",
+                                new JDBCGetMethod[] { JDBCGetMethod.TIMESTAMP });
+                map.put("NCLOB", new JDBCGetMethod[] { JDBCGetMethod.STRING,
+                                JDBCGetMethod.CLOB });
+                map.put("NVARCHAR2", new JDBCGetMethod[] { JDBCGetMethod.BLOB,
+                                JDBCGetMethod.STRING });
+                map.put("LONG RAW", new JDBCGetMethod[] { JDBCGetMethod.BYTES });
+        }
 
-	public JDBCGetMethod[] getJDBCTypes(String type) {
-		return map.get(type);
-	}
+        public JDBCGetMethod[] getJDBCTypes(String type) {
+                return map.get(type);
+        }
 
-	public static int getKeyType(String type) {
-		if ("PRI".equals(type)) {
-			return 0;
-		} else if ("UNI".equals(type)) {
-			return 1;
-		}
-		return -1;
-	}
+        public static int getKeyType(String type) {
+                if ("PRI".equals(type)) {
+                        return 0;
+                } else if ("UNI".equals(type)) {
+                        return 1;
+                }
+                return -1;
+        }
 
-	public static int getMappedJDBCType(String type, String Dataprecision,
-			String Datascale) {
-		if ("VARCHAR".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("NVARCHAR".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("VARCHAR2".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("TEXT".equalsIgnoreCase(type)) {
-			return Types.CLOB;
-		} else if ("NTEXT".equalsIgnoreCase(type)) {
-			return Types.CLOB;
-		} else if ("DATE".equalsIgnoreCase(type)) {
-			// return Types.DATE;
-			// testing using latest jdbc jar version returns this as TIMESTAMP
-			return Types.TIMESTAMP; // changed to TIMESTAMP from DATE for data types
-								// migration
-		} else if ("SMALLINT".equalsIgnoreCase(type)) {
-			return Types.SMALLINT;
-		} else if ("INT".equalsIgnoreCase(type)) {
-			return Types.INTEGER;
-		} else if ("NUMERIC".equalsIgnoreCase(type)) {
-			return Types.BIGINT;
-		} else if ("FLOAT".equalsIgnoreCase(type)) {
-			return Types.FLOAT;
-		} else if ("REAL".equalsIgnoreCase(type)) {
-			return Types.FLOAT;
-		} else if ("DOUBLE".equalsIgnoreCase(type)) {
-			return Types.DOUBLE;
-		} else if ("DECIMAL".equalsIgnoreCase(type)) {
-			return Types.BIGINT;
-		} else if ("RAW".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		} else if ("DATETIME".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		} else if ("DATETIME2".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("TIMESTAMP".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		} else if ("TIME".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("CHAR".equalsIgnoreCase(type)) {
-			return Types.CHAR;
-		} else if ("CLOB".equalsIgnoreCase(type)) {
-			return Types.CLOB;
-		} else if ("NCHAR".equalsIgnoreCase(type)) {
-			return Types.CHAR;
-		} else if ("TIMESTAMP(6)".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		} else if ("TIMESTAMPLTZ".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		} else if ("BLOB".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		} else if ("BINARY".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		} else if ("BINARY_FLOAT".equalsIgnoreCase(type)) {
-			return Types.FLOAT;
-		} else if ("NUMBER".equalsIgnoreCase(type)) {
-			if ("0".equalsIgnoreCase(Datascale)) {
-				return Types.NUMERIC;
-			} else if ("2".equalsIgnoreCase(Datascale)) {
-				return Types.INTEGER;
-			}
-			return Types.DECIMAL;
-		} else if ("BINARY_DOUBLE".equalsIgnoreCase(type)) {
-			return Types.DOUBLE;
-		} else if ("TIMESTAMP(6) WITH TIME ZONE".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		} else if ("TIMESTAMP(6) WITH LOCAL TIME ZONE".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		} else if ("LONG".equalsIgnoreCase(type)) {
-			return Types.CLOB;
-		} else if ("NCLOB".equalsIgnoreCase(type)) {
-			return Types.CLOB;
-		} else if ("NVARCHAR2".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("LONG RAW".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		} else if ("TIMESTAMP(3)".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		} else if ("TIMESTAMP(0)".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		}else if ("BFILE".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		}
-		return 0;
-	}
+        public static int getMappedJDBCType(String type, String Dataprecision,
+                        String Datascale) {
+                if ("VARCHAR".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("NVARCHAR".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("VARCHAR2".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("TEXT".equalsIgnoreCase(type)) {
+                        return Types.CLOB;
+                } else if ("NTEXT".equalsIgnoreCase(type)) {
+                        return Types.CLOB;
+                } else if ("DATE".equalsIgnoreCase(type)) {
+                        // return Types.DATE;
+                        // testing using latest jdbc jar version returns this as TIMESTAMP
+                        return Types.TIMESTAMP; // changed to TIMESTAMP from DATE for data types
+                                                                // migration
+                } else if ("SMALLINT".equalsIgnoreCase(type)) {
+                        return Types.SMALLINT;
+                } else if ("INT".equalsIgnoreCase(type)) {
+                        return Types.INTEGER;
+                } else if ("NUMERIC".equalsIgnoreCase(type)) {
+                        return Types.BIGINT;
+                } else if ("FLOAT".equalsIgnoreCase(type)) {
+                        return Types.FLOAT;
+                } else if ("REAL".equalsIgnoreCase(type)) {
+                        return Types.FLOAT;
+                } else if ("DOUBLE".equalsIgnoreCase(type)) {
+                        return Types.DOUBLE;
+                } else if ("DECIMAL".equalsIgnoreCase(type)) {
+                        return Types.BIGINT;
+                } else if ("RAW".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                } else if ("DATETIME".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                } else if ("DATETIME2".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("TIMESTAMP".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                } else if ("TIME".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("CHAR".equalsIgnoreCase(type)) {
+                        return Types.CHAR;
+                } else if ("CLOB".equalsIgnoreCase(type)) {
+                        return Types.CLOB;
+                } else if ("NCHAR".equalsIgnoreCase(type)) {
+                        return Types.CHAR;
+                } else if ("TIMESTAMP(6)".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                } else if ("TIMESTAMPLTZ".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                } else if ("BLOB".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                } else if ("BINARY".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                } else if ("BINARY_FLOAT".equalsIgnoreCase(type)) {
+                        return Types.FLOAT;
+                } else if ("NUMBER".equalsIgnoreCase(type)) {
+                        if ("0".equalsIgnoreCase(Datascale)) {
+                                return Types.NUMERIC;
+                        } else if ("2".equalsIgnoreCase(Datascale)) {
+                                return Types.INTEGER;
+                        }
+                        return Types.DECIMAL;
+                } else if ("BINARY_DOUBLE".equalsIgnoreCase(type)) {
+                        return Types.DOUBLE;
+                } else if ("TIMESTAMP(6) WITH TIME ZONE".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                } else if ("TIMESTAMP(6) WITH LOCAL TIME ZONE".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                } else if ("LONG".equalsIgnoreCase(type)) {
+                        return Types.CLOB;
+                } else if ("NCLOB".equalsIgnoreCase(type)) {
+                        return Types.CLOB;
+                } else if ("NVARCHAR2".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("LONG RAW".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                } else if ("TIMESTAMP(3)".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                } else if ("TIMESTAMP(0)".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                }else if ("BFILE".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                }
+                return 0;
+        }
 
-	public static String getMappedLength(String type, String length,
-			String Dataprecision, String Datascale) {
-		if ("VARCHAR".equalsIgnoreCase(type)) {
-			return length;
-		} else if ("NVARCHAR".equalsIgnoreCase(type)) {
-			return length;
-		} else if ("VARCHAR2".equalsIgnoreCase(type)) {
-			if ("20".equalsIgnoreCase(length)) {
-				return "20";
-			}
-			return "4000";
-		} else if ("TEXT".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("NTEXT".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("DATE".equalsIgnoreCase(type)) {
-			// return "8";
-			// latest jdbc jar treats this as TIMESTAMP
-			return "12"; // changed to 8 from 12 for data types migration
-		} else if ("INT".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("FLOAT".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("DOUBLE".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("DECIMAL".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("RAW".equalsIgnoreCase(type)) {
-			if ("2000".equalsIgnoreCase(length)) {
-				return "2000";
-			}
-			return "1000";
-		} else if ("DATETIME".equalsIgnoreCase(type)) {
-			return "12";
-		} else if ("TIMESTAMP".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("CHAR".equalsIgnoreCase(type)) {
-			if ("20".equalsIgnoreCase(length)) {
-				return "20";
-			}
-			return "2000";
-		} else if ("TINYTEXT".equalsIgnoreCase(type)) {
-			return "255";
-		} else if ("BLOB".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("CLOB".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("BINARY".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("VARBINARY".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("TIMESTAMP(6)".equalsIgnoreCase(type)) {
-			return "12";
-		} else if ("NCHAR".equalsIgnoreCase(type)) {
-			if ("40".equalsIgnoreCase(length)) {
-				return "20";
-			}
-			return "1000";
-		} else if ("REAL".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("NUMERIC".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("NUMBER".equalsIgnoreCase(type)) {
-			if ("0".equalsIgnoreCase(Datascale)) {
-				return "32";
-			} else if ("2".equalsIgnoreCase(Datascale)) {
-				return "4";
-			}
-			return "8";
-		} else if ("TIME".equalsIgnoreCase(type)) {
-			return "16";
-		} else if ("BINARY_FLOAT".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("BINARY_DOUBLE".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("TIMESTAMP(6) WITH TIME ZONE".equalsIgnoreCase(type)) {
-			return "12";
-		} else if ("TIMESTAMP(6) WITH LOCAL TIME ZONE".equalsIgnoreCase(type)) {
-			return "12";
-		} else if ("TIMESTAMPLTZ".equalsIgnoreCase(type)) {
-			return "12";
-		} else if ("LONG".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("NCLOB".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("NVARCHAR2".equalsIgnoreCase(type)) {
-			if ("40".equalsIgnoreCase(length)) {
-				return "20";
-			}
-			return "2000";
-		} else if ("LONG RAW".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("TIMESTAMP(3)".equalsIgnoreCase(type)
-				|| "TIMESTAMP(0)".equalsIgnoreCase(type)) {
-			return "12";
-		}else if ("BFILE".equalsIgnoreCase(type)) {
-			return "8";
-		}
-		return null;
-	}
+        public static String getMappedLength(String type, String length,
+                        String Dataprecision, String Datascale) {
+                if ("VARCHAR".equalsIgnoreCase(type)) {
+                        return length;
+                } else if ("NVARCHAR".equalsIgnoreCase(type)) {
+                        return length;
+                } else if ("VARCHAR2".equalsIgnoreCase(type)) {
+                        if ("20".equalsIgnoreCase(length)) {
+                                return "20";
+                        }
+                        return "4000";
+                } else if ("TEXT".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("NTEXT".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("DATE".equalsIgnoreCase(type)) {
+                        // return "8";
+                        // latest jdbc jar treats this as TIMESTAMP
+                        return "12"; // changed to 8 from 12 for data types migration
+                } else if ("INT".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("FLOAT".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("DOUBLE".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("DECIMAL".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("RAW".equalsIgnoreCase(type)) {
+                        if ("2000".equalsIgnoreCase(length)) {
+                                return "2000";
+                        }
+                        return "1000";
+                } else if ("DATETIME".equalsIgnoreCase(type)) {
+                        return "12";
+                } else if ("TIMESTAMP".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("CHAR".equalsIgnoreCase(type)) {
+                        if ("20".equalsIgnoreCase(length)) {
+                                return "20";
+                        }
+                        return "2000";
+                } else if ("TINYTEXT".equalsIgnoreCase(type)) {
+                        return "255";
+                } else if ("BLOB".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("CLOB".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("BINARY".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("VARBINARY".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("TIMESTAMP(6)".equalsIgnoreCase(type)) {
+                        return "12";
+                } else if ("NCHAR".equalsIgnoreCase(type)) {
+                        if ("40".equalsIgnoreCase(length)) {
+                                return "20";
+                        }
+                        return "1000";
+                } else if ("REAL".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("NUMERIC".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("NUMBER".equalsIgnoreCase(type)) {
+                        if ("0".equalsIgnoreCase(Datascale)) {
+                                return "32";
+                        } else if ("2".equalsIgnoreCase(Datascale)) {
+                                return "4";
+                        }
+                        return "8";
+                } else if ("TIME".equalsIgnoreCase(type)) {
+                        return "16";
+                } else if ("BINARY_FLOAT".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("BINARY_DOUBLE".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("TIMESTAMP(6) WITH TIME ZONE".equalsIgnoreCase(type)) {
+                        return "12";
+                } else if ("TIMESTAMP(6) WITH LOCAL TIME ZONE".equalsIgnoreCase(type)) {
+                        return "12";
+                } else if ("TIMESTAMPLTZ".equalsIgnoreCase(type)) {
+                        return "12";
+                } else if ("LONG".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("NCLOB".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("NVARCHAR2".equalsIgnoreCase(type)) {
+                        if ("40".equalsIgnoreCase(length)) {
+                                return "20";
+                        }
+                        return "2000";
+                } else if ("LONG RAW".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("TIMESTAMP(3)".equalsIgnoreCase(type)
+                                || "TIMESTAMP(0)".equalsIgnoreCase(type)) {
+                        return "12";
+                }else if ("BFILE".equalsIgnoreCase(type)) {
+                        return "8";
+                }
+                return null;
+        }
 
-	public static String getMappedDefault(String type, String defaultValue) {
-		if ("SMALLINT".equalsIgnoreCase(type)
-				|| "MEDIUMINT".equalsIgnoreCase(type)
-				|| "BIGINT".equalsIgnoreCase(type)
-				|| "INT".equalsIgnoreCase(type)) {
-			return defaultValue == null ? null : "'" + defaultValue + "'";
-		} else if ("TIMESTAMP".equalsIgnoreCase(type)) {
-			return "CURRENT_TIMESTAMP".equals(defaultValue) ? "'NOW'"
-					: defaultValue;
-		}
-		return defaultValue;
-	}
+        public static String getMappedDefault(String type, String defaultValue) {
+                if ("SMALLINT".equalsIgnoreCase(type)
+                                || "MEDIUMINT".equalsIgnoreCase(type)
+                                || "BIGINT".equalsIgnoreCase(type)
+                                || "INT".equalsIgnoreCase(type)) {
+                        return defaultValue == null ? null : "'" + defaultValue + "'";
+                } else if ("TIMESTAMP".equalsIgnoreCase(type)) {
+                        return "CURRENT_TIMESTAMP".equals(defaultValue) ? "'NOW()'"
+                                        : defaultValue;
+                }
+                return defaultValue;
+        }
 
-	public boolean isCaseSensitive() {
-		return false;
-	}
+        public boolean isCaseSensitive() {
+                return false;
+        }
 }

--- a/core/src/test/java/com/nuodb/migrator/integration/types/PostgreSQLTypes.java
+++ b/core/src/test/java/com/nuodb/migrator/integration/types/PostgreSQLTypes.java
@@ -35,291 +35,291 @@ import java.util.Map;
  * @author Krishnamoorthy Dhandapani
  */
 public class PostgreSQLTypes implements DatabaseTypes {
-	private static Map<String, JDBCGetMethod[]> map = new HashMap<String, JDBCGetMethod[]>();
+        private static Map<String, JDBCGetMethod[]> map = new HashMap<String, JDBCGetMethod[]>();
 
-	static {
-		map.put("BOOLEAN", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
-		map.put("BOOL", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
+        static {
+                map.put("BOOLEAN", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
+                map.put("BOOL", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
 
-		map.put("TEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("TEXT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
 
-		map.put("BIGINT", new JDBCGetMethod[] { JDBCGetMethod.LONG });
+                map.put("BIGINT", new JDBCGetMethod[] { JDBCGetMethod.LONG });
 
-		map.put("CHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("BPCHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("CHARACTER", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("BIT", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT });
-		map.put("VARBIT", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.STRING });
-		map.put("BIGSERIAL", new JDBCGetMethod[] { JDBCGetMethod.LONG });
-		map.put("SERIAL8", new JDBCGetMethod[] { JDBCGetMethod.LONG });
-		map.put("SMALLINT", new JDBCGetMethod[] { JDBCGetMethod.SHORT });
-		map.put("INT8", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT, JDBCGetMethod.LONG });
-		map.put("INT4", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT });
-		map.put("INT2", new JDBCGetMethod[] { JDBCGetMethod.SHORT });
-		map.put("REAL", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
-		map.put("NUMERIC", new JDBCGetMethod[] { JDBCGetMethod.INT });
-		map.put("INT", new JDBCGetMethod[] { JDBCGetMethod.INT });
-		map.put("MONEY", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
+                map.put("CHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("BPCHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("CHARACTER", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("BIT", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT });
+                map.put("VARBIT", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.STRING });
+                map.put("BIGSERIAL", new JDBCGetMethod[] { JDBCGetMethod.LONG });
+                map.put("SERIAL8", new JDBCGetMethod[] { JDBCGetMethod.LONG });
+                map.put("SMALLINT", new JDBCGetMethod[] { JDBCGetMethod.SHORT });
+                map.put("INT8", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT, JDBCGetMethod.LONG });
+                map.put("INT4", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT });
+                map.put("INT2", new JDBCGetMethod[] { JDBCGetMethod.SHORT });
+                map.put("REAL", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
+                map.put("NUMERIC", new JDBCGetMethod[] { JDBCGetMethod.INT });
+                map.put("INT", new JDBCGetMethod[] { JDBCGetMethod.INT });
+                map.put("MONEY", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
 
-		map.put("INTERVAL", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("INET", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("CIDR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("BYTEA", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
+                map.put("INTERVAL", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("INET", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("CIDR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("BYTEA", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
 
-		map.put("INTEGER", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT });
-		map.put("SMALLINT", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT });
-		map.put("MEDIUMINT", new JDBCGetMethod[] { JDBCGetMethod.INT,
-				JDBCGetMethod.LONG });
-		map.put("BIGINT", new JDBCGetMethod[] { JDBCGetMethod.INT,
-				JDBCGetMethod.LONG });
+                map.put("INTEGER", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT });
+                map.put("SMALLINT", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT });
+                map.put("MEDIUMINT", new JDBCGetMethod[] { JDBCGetMethod.INT,
+                                JDBCGetMethod.LONG });
+                map.put("BIGINT", new JDBCGetMethod[] { JDBCGetMethod.INT,
+                                JDBCGetMethod.LONG });
 
-		map.put("FLOAT", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
-		map.put("FLOAT4", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
-		map.put("DOUBLE", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
-		// TODO: revert back to double after bug fix
-		// JDBCType.DOUBLE });
-		map.put("DATE", new JDBCGetMethod[] { JDBCGetMethod.DATE });
-		map.put("DATETIME", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIMESTAMP });
-		map.put("TIMESTAMP", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIMESTAMP });
-		map.put("TIMESTAMPTZ", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIMESTAMP });
-		map.put("TIME", new JDBCGetMethod[] { JDBCGetMethod.TIME });
-		map.put("TIMETZ", new JDBCGetMethod[] { JDBCGetMethod.TIME });
-		map.put("BIT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("BIT VARYING", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("BYTEA", new JDBCGetMethod[] { JDBCGetMethod.BYTES });
-		map.put("FLOAT8", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
-		map.put("CHARACTER VARYING",
-				new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("SERIAL", new JDBCGetMethod[] { JDBCGetMethod.INT });
-		map.put("SERIAL4", new JDBCGetMethod[] { JDBCGetMethod.INT });
-		map.put("VARCHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("FLOAT", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
+                map.put("FLOAT4", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
+                map.put("DOUBLE", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
+                // TODO: revert back to double after bug fix
+                // JDBCType.DOUBLE });
+                map.put("DATE", new JDBCGetMethod[] { JDBCGetMethod.DATE });
+                map.put("DATETIME", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIMESTAMP });
+                map.put("TIMESTAMP", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIMESTAMP });
+                map.put("TIMESTAMPTZ", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIMESTAMP });
+                map.put("TIME", new JDBCGetMethod[] { JDBCGetMethod.TIME });
+                map.put("TIMETZ", new JDBCGetMethod[] { JDBCGetMethod.TIME });
+                map.put("BIT", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("BIT VARYING", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("BYTEA", new JDBCGetMethod[] { JDBCGetMethod.BYTES });
+                map.put("FLOAT8", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
+                map.put("CHARACTER VARYING",
+                                new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("SERIAL", new JDBCGetMethod[] { JDBCGetMethod.INT });
+                map.put("SERIAL4", new JDBCGetMethod[] { JDBCGetMethod.INT });
+                map.put("VARCHAR", new JDBCGetMethod[] { JDBCGetMethod.STRING });
 
-		map.put("TIME WITH TIME ZONE",
-				new JDBCGetMethod[] { JDBCGetMethod.TIMESTAMP });
-		map.put("TIM WITHOUT TIME ZONE",
-				new JDBCGetMethod[] { JDBCGetMethod.TIMESTAMP });
-		map.put("TIMESTAMP WITH TIME ZONE",
-				new JDBCGetMethod[] { JDBCGetMethod.TIMESTAMP });
-		map.put("TIMESTAMP WITHOUT TIME ZONE",
-				new JDBCGetMethod[] { JDBCGetMethod.TIMESTAMP });
+                map.put("TIME WITH TIME ZONE",
+                                new JDBCGetMethod[] { JDBCGetMethod.TIMESTAMP });
+                map.put("TIM WITHOUT TIME ZONE",
+                                new JDBCGetMethod[] { JDBCGetMethod.TIMESTAMP });
+                map.put("TIMESTAMP WITH TIME ZONE",
+                                new JDBCGetMethod[] { JDBCGetMethod.TIMESTAMP });
+                map.put("TIMESTAMP WITHOUT TIME ZONE",
+                                new JDBCGetMethod[] { JDBCGetMethod.TIMESTAMP });
 
-	}
+        }
 
-	public JDBCGetMethod[] getJDBCTypes(String type) {
-		if (isCaseSensitive()) {
-			return map.get(type);
-		} else {
-			return map.get(type.toUpperCase());
-		}
-	}
+        public JDBCGetMethod[] getJDBCTypes(String type) {
+                if (isCaseSensitive()) {
+                        return map.get(type);
+                } else {
+                        return map.get(type.toUpperCase());
+                }
+        }
 
-	public static int getKeyType(String type) {
-		if ("PRIMARY KEY".equals(type)) {
-			return 0;
-		} else if ("UNIQUE".equals(type)) {
-			return 1;
-		}
-		return -1;
-	}
+        public static int getKeyType(String type) {
+                if ("PRIMARY KEY".equals(type)) {
+                        return 0;
+                } else if ("UNIQUE".equals(type)) {
+                        return 1;
+                }
+                return -1;
+        }
 
-	public static int getMappedJDBCType(String type) {
-		if ("CHAR".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("BPCHAR".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("TEXT".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("SMALLINT".equalsIgnoreCase(type)) {
-			return Types.SMALLINT;
-		} else if ("DATE".equalsIgnoreCase(type)) {
-			return Types.DATE;
-		} else if ("SMALLINT".equalsIgnoreCase(type)) {
-			return Types.SMALLINT;
-		} else if ("MEDIUMINT".equalsIgnoreCase(type)) {
-			return Types.INTEGER;
-		} else if ("BIGINT".equalsIgnoreCase(type)) {
-			return Types.BIGINT;
-		} else if ("INTEGER".equalsIgnoreCase(type)) {
-			return Types.INTEGER;
-		} else if ("INT".equalsIgnoreCase(type)) {
-			return Types.INTEGER;
-		} else if ("INT2".equalsIgnoreCase(type)) {
-			return Types.SMALLINT;
-		} else if ("INT4".equalsIgnoreCase(type)) {
-			return Types.SMALLINT;
-		} else if ("INT8".equalsIgnoreCase(type)) {
-			return Types.INTEGER;
-		} else if ("NUMERIC".equalsIgnoreCase(type)) {
-			return Types.INTEGER;
-		} else if ("REAL".equalsIgnoreCase(type)) {
-			return Types.FLOAT;
-		} else if ("FLOAT".equalsIgnoreCase(type)) {
-			return Types.FLOAT;
-		} else if ("FLOAT4".equalsIgnoreCase(type)) {
-			return Types.FLOAT;
-		} else if ("DOUBLE".equalsIgnoreCase(type)) {
-			return Types.DOUBLE;
-		} else if ("DECIMAL".equalsIgnoreCase(type)) {
-			return Types.BIGINT;
-		} else if ("TIME".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		} else if ("TIMETZ".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		} else if ("DATETIME".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		} else if ("TIMESTAMP".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		} else if ("TIMESTAMPTZ".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		} else if ("YEAR".equalsIgnoreCase(type)) {
-			return Types.DATE;
-		} else if ("CHAR".equalsIgnoreCase(type)) {
-			return Types.CHAR;
-		} else if ("CHARACTER".equalsIgnoreCase(type)) {
-			return Types.CHAR;
-		} else if ("BLOB".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		} else if ("MONEY".equalsIgnoreCase(type)) {
-			return Types.DOUBLE;
-		} else if ("INET".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("BIT".equalsIgnoreCase(type)) {
-			return Types.CHAR;
-		} else if ("VARBIT".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("BYTEA".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		} else if ("FLOAT8".equalsIgnoreCase(type)) {
-			return Types.DOUBLE;
-		} else if ("DOUBLE PRECISION".equalsIgnoreCase(type)) {
-			return Types.DOUBLE;
-		} else if ("CHARACTER VARYING".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("BOOLEAN".equalsIgnoreCase(type)) {
-			return Types.BOOLEAN;
-		} else if ("VARCHAR".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("TIME WITH TIME ZONE".equalsIgnoreCase(type)) {
-			return Types.TIME;
-		} else if ("TIME WITHOUT TIME ZONE".equalsIgnoreCase(type)) {
-			return Types.TIME;
-		} else if ("TIMESTAMP WITHOUT TIME ZONE".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		} else if ("TIMESTAMP WITH TIME ZONE".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		}
-		return 0;
-	}
+        public static int getMappedJDBCType(String type) {
+                if ("CHAR".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("BPCHAR".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("TEXT".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("SMALLINT".equalsIgnoreCase(type)) {
+                        return Types.SMALLINT;
+                } else if ("DATE".equalsIgnoreCase(type)) {
+                        return Types.DATE;
+                } else if ("SMALLINT".equalsIgnoreCase(type)) {
+                        return Types.SMALLINT;
+                } else if ("MEDIUMINT".equalsIgnoreCase(type)) {
+                        return Types.INTEGER;
+                } else if ("BIGINT".equalsIgnoreCase(type)) {
+                        return Types.BIGINT;
+                } else if ("INTEGER".equalsIgnoreCase(type)) {
+                        return Types.INTEGER;
+                } else if ("INT".equalsIgnoreCase(type)) {
+                        return Types.INTEGER;
+                } else if ("INT2".equalsIgnoreCase(type)) {
+                        return Types.SMALLINT;
+                } else if ("INT4".equalsIgnoreCase(type)) {
+                        return Types.SMALLINT;
+                } else if ("INT8".equalsIgnoreCase(type)) {
+                        return Types.INTEGER;
+                } else if ("NUMERIC".equalsIgnoreCase(type)) {
+                        return Types.INTEGER;
+                } else if ("REAL".equalsIgnoreCase(type)) {
+                        return Types.FLOAT;
+                } else if ("FLOAT".equalsIgnoreCase(type)) {
+                        return Types.FLOAT;
+                } else if ("FLOAT4".equalsIgnoreCase(type)) {
+                        return Types.FLOAT;
+                } else if ("DOUBLE".equalsIgnoreCase(type)) {
+                        return Types.DOUBLE;
+                } else if ("DECIMAL".equalsIgnoreCase(type)) {
+                        return Types.BIGINT;
+                } else if ("TIME".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                } else if ("TIMETZ".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                } else if ("DATETIME".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                } else if ("TIMESTAMP".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                } else if ("TIMESTAMPTZ".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                } else if ("YEAR".equalsIgnoreCase(type)) {
+                        return Types.DATE;
+                } else if ("CHAR".equalsIgnoreCase(type)) {
+                        return Types.CHAR;
+                } else if ("CHARACTER".equalsIgnoreCase(type)) {
+                        return Types.CHAR;
+                } else if ("BLOB".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                } else if ("MONEY".equalsIgnoreCase(type)) {
+                        return Types.DOUBLE;
+                } else if ("INET".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("BIT".equalsIgnoreCase(type)) {
+                        return Types.CHAR;
+                } else if ("VARBIT".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("BYTEA".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                } else if ("FLOAT8".equalsIgnoreCase(type)) {
+                        return Types.DOUBLE;
+                } else if ("DOUBLE PRECISION".equalsIgnoreCase(type)) {
+                        return Types.DOUBLE;
+                } else if ("CHARACTER VARYING".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("BOOLEAN".equalsIgnoreCase(type)) {
+                        return Types.BOOLEAN;
+                } else if ("VARCHAR".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("TIME WITH TIME ZONE".equalsIgnoreCase(type)) {
+                        return Types.TIME;
+                } else if ("TIME WITHOUT TIME ZONE".equalsIgnoreCase(type)) {
+                        return Types.TIME;
+                } else if ("TIMESTAMP WITHOUT TIME ZONE".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                } else if ("TIMESTAMP WITH TIME ZONE".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                }
+                return 0;
+        }
 
-	public static String getMappedLength(String type, String length) {
-		if ("CHAR".equalsIgnoreCase(type)) {
-			return length;
-		} else if ("BOOL".equalsIgnoreCase(type)) {
-			return "1";
-		} else if ("TEXT".equalsIgnoreCase(type)) {
-			return "2147483647";
-		} else if ("DATE".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("SMALLINT".equalsIgnoreCase(type)) {
-			return "2";
-		} else if ("MEDIUMINT".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("BIGINT".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("INT".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("INT4".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("INT2".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("INT8".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("FLOAT".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("FLOAT4".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("DOUBLE".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("MONEY".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("DATETIME".equalsIgnoreCase(type)) {
-			return "12";
-		} else if ("TIMESTAMP".equalsIgnoreCase(type)) {
-			return "12";
-		} else if ("TIMESTAMPTZ".equalsIgnoreCase(type)) {
-			return "12";
-		} else if ("TIMETZ".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("TIME WITH TIME ZONE".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("TIME WITHOUT TIME ZONE".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("TIMESTAMP WITH TIME ZONE".equalsIgnoreCase(type)) {
-			return "12";
-		} else if ("TIMESTAMP WITHOUT TIME ZONE".equalsIgnoreCase(type)) {
-			return "12";
-		} else if ("BIT".equalsIgnoreCase(type)) {
-			return length;
-		} else if ("REAL".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("INET".equalsIgnoreCase(type)) {
-			return "15";
-		} else if ("BIT VARYING".equalsIgnoreCase(type)) {
-			return length;
-		} else if ("BYTEA".equalsIgnoreCase(type)) {
-			return "2147483647";
-		} else if ("DOUBLE PRECISION".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("CHARACTER VARYING".equalsIgnoreCase(type)) {
-			return length;
-		} else if ("CHARACTER".equalsIgnoreCase(type)) {
-			return length;
-		} else if ("NUMERIC".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("SERIAL8".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("SERIAL4".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("SERIAL".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("DECIMAL".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("INTEGER".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("VARCHAR".equalsIgnoreCase(type)) {
-			return "2147483647";
-		} else if ("float8".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("BOOLEAN".equalsIgnoreCase(type)) {
-			return "2";
-		}
+        public static String getMappedLength(String type, String length) {
+                if ("CHAR".equalsIgnoreCase(type)) {
+                        return length;
+                } else if ("BOOL".equalsIgnoreCase(type)) {
+                        return "1";
+                } else if ("TEXT".equalsIgnoreCase(type)) {
+                        return "2147483647";
+                } else if ("DATE".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("SMALLINT".equalsIgnoreCase(type)) {
+                        return "2";
+                } else if ("MEDIUMINT".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("BIGINT".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("INT".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("INT4".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("INT2".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("INT8".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("FLOAT".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("FLOAT4".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("DOUBLE".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("MONEY".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("DATETIME".equalsIgnoreCase(type)) {
+                        return "12";
+                } else if ("TIMESTAMP".equalsIgnoreCase(type)) {
+                        return "12";
+                } else if ("TIMESTAMPTZ".equalsIgnoreCase(type)) {
+                        return "12";
+                } else if ("TIMETZ".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("TIME WITH TIME ZONE".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("TIME WITHOUT TIME ZONE".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("TIMESTAMP WITH TIME ZONE".equalsIgnoreCase(type)) {
+                        return "12";
+                } else if ("TIMESTAMP WITHOUT TIME ZONE".equalsIgnoreCase(type)) {
+                        return "12";
+                } else if ("BIT".equalsIgnoreCase(type)) {
+                        return length;
+                } else if ("REAL".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("INET".equalsIgnoreCase(type)) {
+                        return "15";
+                } else if ("BIT VARYING".equalsIgnoreCase(type)) {
+                        return length;
+                } else if ("BYTEA".equalsIgnoreCase(type)) {
+                        return "2147483647";
+                } else if ("DOUBLE PRECISION".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("CHARACTER VARYING".equalsIgnoreCase(type)) {
+                        return length;
+                } else if ("CHARACTER".equalsIgnoreCase(type)) {
+                        return length;
+                } else if ("NUMERIC".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("SERIAL8".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("SERIAL4".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("SERIAL".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("DECIMAL".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("INTEGER".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("VARCHAR".equalsIgnoreCase(type)) {
+                        return "2147483647";
+                } else if ("float8".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("BOOLEAN".equalsIgnoreCase(type)) {
+                        return "2";
+                }
 
-		return null;
-	}
+                return null;
+        }
 
-	public static String getMappedDefault(String type, String defaultValue) {
-		if ("SMALLINT".equalsIgnoreCase(type)
-				|| "MEDIUMINT".equalsIgnoreCase(type)
-				|| "BIGINT".equalsIgnoreCase(type)
-				|| "INT".equalsIgnoreCase(type)) {
-			return defaultValue == null ? null : "'" + defaultValue + "'";
-		} else if ("TIMESTAMP".equalsIgnoreCase(type)) {
-			return "CURRENT_TIMESTAMP".equals(defaultValue) ? "'NOW'"
-					: defaultValue;
-		}
-		return defaultValue;
-	}
+        public static String getMappedDefault(String type, String defaultValue) {
+                if ("SMALLINT".equalsIgnoreCase(type)
+                                || "MEDIUMINT".equalsIgnoreCase(type)
+                                || "BIGINT".equalsIgnoreCase(type)
+                                || "INT".equalsIgnoreCase(type)) {
+                        return defaultValue == null ? null : "'" + defaultValue + "'";
+                } else if ("TIMESTAMP".equalsIgnoreCase(type)) {
+                        return "CURRENT_TIMESTAMP".equals(defaultValue) ? "'NOW()'"
+                                        : defaultValue;
+                }
+                return defaultValue;
+        }
 
-	public boolean isCaseSensitive() {
-		return false;
-	}
+        public boolean isCaseSensitive() {
+                return false;
+        }
 }

--- a/core/src/test/java/com/nuodb/migrator/integration/types/PostgreSQLTypes.java
+++ b/core/src/test/java/com/nuodb/migrator/integration/types/PostgreSQLTypes.java
@@ -313,7 +313,7 @@ public class PostgreSQLTypes implements DatabaseTypes {
                                 || "INT".equalsIgnoreCase(type)) {
                         return defaultValue == null ? null : "'" + defaultValue + "'";
                 } else if ("TIMESTAMP".equalsIgnoreCase(type)) {
-                        return "CURRENT_TIMESTAMP".equals(defaultValue) ? "'NOW()'"
+                        return "CURRENT_TIMESTAMP".equals(defaultValue) ? "NOW()"
                                         : defaultValue;
                 }
                 return defaultValue;

--- a/core/src/test/java/com/nuodb/migrator/integration/types/SQLServerTypes.java
+++ b/core/src/test/java/com/nuodb/migrator/integration/types/SQLServerTypes.java
@@ -35,292 +35,292 @@ import java.util.Map;
  * @author Krishnamoorthy Dhandapani
  */
 public class SQLServerTypes implements DatabaseTypes {
-	private static Map<String, JDBCGetMethod[]> map = new HashMap<String, JDBCGetMethod[]>();
+        private static Map<String, JDBCGetMethod[]> map = new HashMap<String, JDBCGetMethod[]>();
 
-	static {
-		map.put("bool", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
-		map.put("boolean", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
-		map.put("bit", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT });
-		map.put("long", new JDBCGetMethod[] { JDBCGetMethod.LONG });
+        static {
+                map.put("bool", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
+                map.put("boolean", new JDBCGetMethod[] { JDBCGetMethod.BOOLEAN });
+                map.put("bit", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT });
+                map.put("long", new JDBCGetMethod[] { JDBCGetMethod.LONG });
 
-		map.put("varchar", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("nvarchar", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("text", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("tinytext", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("mediumtext", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("longtext", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("char", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("uniqueidentifier",
-				new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("nchar", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("ntext", new JDBCGetMethod[] { JDBCGetMethod.STRING });
-		map.put("int", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT });
-		map.put("int identity", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT });
-		map.put("numeric", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.LONG, JDBCGetMethod.INT });
-		map.put("tinyint", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT });
-		map.put("smallint", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
-				JDBCGetMethod.INT });
-		map.put("mediumint", new JDBCGetMethod[] { JDBCGetMethod.INT,
-				JDBCGetMethod.LONG });
-		map.put("bigint", new JDBCGetMethod[] { JDBCGetMethod.INT,
-				JDBCGetMethod.LONG });
+                map.put("varchar", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("nvarchar", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("text", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("tinytext", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("mediumtext", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("longtext", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("char", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("uniqueidentifier",
+                                new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("nchar", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("ntext", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("int", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT });
+                map.put("int identity", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT });
+                map.put("numeric", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.LONG, JDBCGetMethod.INT });
+                map.put("tinyint", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT });
+                map.put("smallint", new JDBCGetMethod[] { JDBCGetMethod.SHORT,
+                                JDBCGetMethod.INT });
+                map.put("mediumint", new JDBCGetMethod[] { JDBCGetMethod.INT,
+                                JDBCGetMethod.LONG });
+                map.put("bigint", new JDBCGetMethod[] { JDBCGetMethod.INT,
+                                JDBCGetMethod.LONG });
 
-		map.put("float", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
-		map.put("real", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
-		map.put("double", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
-		map.put("money", new JDBCGetMethod[] { JDBCGetMethod.INT,
-				JDBCGetMethod.LONG });
-		map.put("smallmoney", new JDBCGetMethod[] { JDBCGetMethod.INT,
-				JDBCGetMethod.LONG });
-		// TODO: revert back to double after bug fix
-		// JDBCType.DOUBLE });
-		map.put("decimal", new JDBCGetMethod[] { JDBCGetMethod.STRING });
+                map.put("float", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
+                map.put("real", new JDBCGetMethod[] { JDBCGetMethod.FLOAT });
+                map.put("double", new JDBCGetMethod[] { JDBCGetMethod.DOUBLE });
+                map.put("money", new JDBCGetMethod[] { JDBCGetMethod.INT,
+                                JDBCGetMethod.LONG });
+                map.put("smallmoney", new JDBCGetMethod[] { JDBCGetMethod.INT,
+                                JDBCGetMethod.LONG });
+                // TODO: revert back to double after bug fix
+                // JDBCType.DOUBLE });
+                map.put("decimal", new JDBCGetMethod[] { JDBCGetMethod.STRING });
 
-		map.put("date", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIMESTAMP });
-		map.put("datetime", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIMESTAMP });
-		map.put("smalldatetime", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIMESTAMP });
-		map.put("datetime2", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIMESTAMP });
-		map.put("timestamp", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
-		map.put("time", new JDBCGetMethod[] { JDBCGetMethod.DATE,
-				JDBCGetMethod.TIME, JDBCGetMethod.TIMESTAMP });
-		map.put("image", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
-		map.put("binary", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
-		map.put("varbinary", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
-	}
+                map.put("date", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIMESTAMP });
+                map.put("datetime", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIMESTAMP });
+                map.put("smalldatetime", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIMESTAMP });
+                map.put("datetime2", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIMESTAMP });
+                map.put("timestamp", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
+                map.put("time", new JDBCGetMethod[] { JDBCGetMethod.DATE,
+                                JDBCGetMethod.TIME, JDBCGetMethod.TIMESTAMP });
+                map.put("image", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
+                map.put("binary", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
+                map.put("varbinary", new JDBCGetMethod[] { JDBCGetMethod.BLOB });
+        }
 
-	public JDBCGetMethod[] getJDBCTypes(String type) {
-		return map.get(type);
-	}
+        public JDBCGetMethod[] getJDBCTypes(String type) {
+                return map.get(type);
+        }
 
-	public static int getKeyType(String type) {
-		if ("PRI".equals(type)) {
-			return 0;
-		} else if ("UNI".equals(type)) {
-			return 1;
-		}
-		return -1;
-	}
+        public static int getKeyType(String type) {
+                if ("PRI".equals(type)) {
+                        return 0;
+                } else if ("UNI".equals(type)) {
+                        return 1;
+                }
+                return -1;
+        }
 
-	public static int getMappedJDBCType(String type, String precision) {
-		if ("varchar".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("nvarchar".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("tinyint".equalsIgnoreCase(type)) {
-			return Types.SMALLINT;
-		} else if ("text".equalsIgnoreCase(type)) {
-			return Types.CLOB;
-		} else if ("ntext".equalsIgnoreCase(type)) {
-			return Types.CLOB;
-		} else if ("date".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("smallint".equalsIgnoreCase(type)) {
-			return Types.SMALLINT;
-		} else if ("mediumint".equalsIgnoreCase(type)) {
-			return Types.INTEGER;
-		} else if ("bigint".equalsIgnoreCase(type)) {
-			return Types.BIGINT;
-		} else if ("int".equalsIgnoreCase(type)) {
-			return Types.INTEGER;
-		} else if ("numeric".equalsIgnoreCase(type)) {
-			if ("38".equalsIgnoreCase(precision)) {
-				return Types.NUMERIC;
-			}
-			if ("18".equalsIgnoreCase(precision)) {
-				return Types.BIGINT;
-			}
-			return Types.INTEGER;
-		} else if ("float".equalsIgnoreCase(type)) {
-			return Types.DOUBLE;
-		} else if ("real".equalsIgnoreCase(type)) {
-			return Types.FLOAT;
-		} else if ("double".equalsIgnoreCase(type)) {
-			return Types.DOUBLE;
-		} else if ("decimal".equalsIgnoreCase(type)) {
-			if ("18".equalsIgnoreCase(precision)) {
-				return Types.BIGINT;
-			}
-			return Types.NUMERIC;
-		} else if ("money".equalsIgnoreCase(type)) {
-			return Types.BIGINT;
-		} else if ("smallmoney".equalsIgnoreCase(type)) {
-			return Types.BIGINT;
-		} else if ("datetime".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		} else if ("smalldatetime".equalsIgnoreCase(type)) {
-			return Types.TIMESTAMP;
-		} else if ("datetime2".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("timestamp".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		} else if ("time".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("char".equalsIgnoreCase(type)) {
-			return Types.CHAR;
-		} else if ("uniqueidentifier".equalsIgnoreCase(type)) {
-			return Types.CHAR;
-		} else if ("datetimeoffset".equalsIgnoreCase(type)) {
-			return Types.VARCHAR;
-		} else if ("nchar".equalsIgnoreCase(type)) {
-			return Types.CHAR;
-		} else if ("bit".equalsIgnoreCase(type)) {
-			return Types.BOOLEAN;
-		} else if ("image".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		} else if ("binary".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		} else if ("varbinary".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		} else if ("hierarchyid".equalsIgnoreCase(type)) {
-			return Types.BLOB;
-		}
-		return 0;
-	}
+        public static int getMappedJDBCType(String type, String precision) {
+                if ("varchar".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("nvarchar".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("tinyint".equalsIgnoreCase(type)) {
+                        return Types.SMALLINT;
+                } else if ("text".equalsIgnoreCase(type)) {
+                        return Types.CLOB;
+                } else if ("ntext".equalsIgnoreCase(type)) {
+                        return Types.CLOB;
+                } else if ("date".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("smallint".equalsIgnoreCase(type)) {
+                        return Types.SMALLINT;
+                } else if ("mediumint".equalsIgnoreCase(type)) {
+                        return Types.INTEGER;
+                } else if ("bigint".equalsIgnoreCase(type)) {
+                        return Types.BIGINT;
+                } else if ("int".equalsIgnoreCase(type)) {
+                        return Types.INTEGER;
+                } else if ("numeric".equalsIgnoreCase(type)) {
+                        if ("38".equalsIgnoreCase(precision)) {
+                                return Types.NUMERIC;
+                        }
+                        if ("18".equalsIgnoreCase(precision)) {
+                                return Types.BIGINT;
+                        }
+                        return Types.INTEGER;
+                } else if ("float".equalsIgnoreCase(type)) {
+                        return Types.DOUBLE;
+                } else if ("real".equalsIgnoreCase(type)) {
+                        return Types.FLOAT;
+                } else if ("double".equalsIgnoreCase(type)) {
+                        return Types.DOUBLE;
+                } else if ("decimal".equalsIgnoreCase(type)) {
+                        if ("18".equalsIgnoreCase(precision)) {
+                                return Types.BIGINT;
+                        }
+                        return Types.NUMERIC;
+                } else if ("money".equalsIgnoreCase(type)) {
+                        return Types.BIGINT;
+                } else if ("smallmoney".equalsIgnoreCase(type)) {
+                        return Types.BIGINT;
+                } else if ("datetime".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                } else if ("smalldatetime".equalsIgnoreCase(type)) {
+                        return Types.TIMESTAMP;
+                } else if ("datetime2".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("timestamp".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                } else if ("time".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("char".equalsIgnoreCase(type)) {
+                        return Types.CHAR;
+                } else if ("uniqueidentifier".equalsIgnoreCase(type)) {
+                        return Types.CHAR;
+                } else if ("datetimeoffset".equalsIgnoreCase(type)) {
+                        return Types.VARCHAR;
+                } else if ("nchar".equalsIgnoreCase(type)) {
+                        return Types.CHAR;
+                } else if ("bit".equalsIgnoreCase(type)) {
+                        return Types.BOOLEAN;
+                } else if ("image".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                } else if ("binary".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                } else if ("varbinary".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                } else if ("hierarchyid".equalsIgnoreCase(type)) {
+                        return Types.BLOB;
+                }
+                return 0;
+        }
 
-	public static String getMappedLength(String type, String length,
-			String dataPrecision, String dataScale, String numericPrecision) {
-		if ("varchar".equalsIgnoreCase(type)) {
-			return length;
-		} else if ("nvarchar".equalsIgnoreCase(type)) {
-			return length;
-		} else if ("tinyint".equalsIgnoreCase(type)) {
-			return "2";
-		} else if ("text".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("ntext".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("date".equalsIgnoreCase(type)) {
-			return "10";
-		} else if ("bigint".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("int".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("float".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("double".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("decimal".equalsIgnoreCase(type)) {
-			if ("18".equalsIgnoreCase(dataPrecision)
-					|| (null == dataScale || "0".equalsIgnoreCase(dataScale))) {
-				return "8";
-			}
-			return "32";
-		} else if ("money".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("smallmoney".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("datetime".equalsIgnoreCase(type)) {
-			return "12";
-		} else if ("datetime2".equalsIgnoreCase(type)) {
-			return "27";
-		} else if ("timestamp".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("char".equalsIgnoreCase(type)) {
-			if ("8000".equalsIgnoreCase(length)) {
-				return "8000";
-			}
-			if ("20".equalsIgnoreCase(length)) {
-				return "20";
-			}
-			return "1";
-		} else if ("tinytext".equalsIgnoreCase(type)) {
-			return "255";
-		} else if ("image".equalsIgnoreCase(type)) {
-			return "8";
-		} else if ("datetimeoffset".equalsIgnoreCase(type)) {
-			if ("4".equalsIgnoreCase(numericPrecision)) {
-				return "31";
-			}
-			return "34";
-		} else if ("binary".equalsIgnoreCase(type)) {
-			if ("8000".equalsIgnoreCase(length)) {
-				return "8000";
-			}
-			if ("4".equalsIgnoreCase(length)) {
-				return "4";
-			}
-			return "1";
-		} else if ("varbinary".equalsIgnoreCase(type)) {
-			if ("8000".equalsIgnoreCase(length)) {
-				return "8000";
-			}
-			if ("1".equalsIgnoreCase(length)) {
-				return "1";
-			}
-			return "8";
-		} else if ("bit".equalsIgnoreCase(type)) {
-			return "2";
-		} else if ("nchar".equalsIgnoreCase(type)) {
-			if ("4000".equalsIgnoreCase(length)) {
-				return "4000";
-			}
-			if ("10".equalsIgnoreCase(length)) {
-				return "10";
-			}
-			return "1";
-		} else if ("real".equalsIgnoreCase(type)) {
-			return "4";
-		} else if ("numeric".equalsIgnoreCase(type)) {
-			if ("18".equalsIgnoreCase(dataPrecision)
-					|| (null == dataScale || "0".equalsIgnoreCase(dataScale))) {
-				return "8";
-			}
-			return "32";
-		} else if ("smalldatetime".equalsIgnoreCase(type)) {
-			return "12";
-		} else if ("smallint".equalsIgnoreCase(type)) {
-			return "2";
-		} else if ("time".equalsIgnoreCase(type)) {
-			return "16";
-		} else if ("uniqueidentifier".equalsIgnoreCase(type)) {
-			return "36";
-		} else if ("hierarchyid".equalsIgnoreCase(type)) {
-			return "8";
-		}
-		return null;
-	}
+        public static String getMappedLength(String type, String length,
+                        String dataPrecision, String dataScale, String numericPrecision) {
+                if ("varchar".equalsIgnoreCase(type)) {
+                        return length;
+                } else if ("nvarchar".equalsIgnoreCase(type)) {
+                        return length;
+                } else if ("tinyint".equalsIgnoreCase(type)) {
+                        return "2";
+                } else if ("text".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("ntext".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("date".equalsIgnoreCase(type)) {
+                        return "10";
+                } else if ("bigint".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("int".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("float".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("double".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("decimal".equalsIgnoreCase(type)) {
+                        if ("18".equalsIgnoreCase(dataPrecision)
+                                        || (null == dataScale || "0".equalsIgnoreCase(dataScale))) {
+                                return "8";
+                        }
+                        return "32";
+                } else if ("money".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("smallmoney".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("datetime".equalsIgnoreCase(type)) {
+                        return "12";
+                } else if ("datetime2".equalsIgnoreCase(type)) {
+                        return "27";
+                } else if ("timestamp".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("char".equalsIgnoreCase(type)) {
+                        if ("8000".equalsIgnoreCase(length)) {
+                                return "8000";
+                        }
+                        if ("20".equalsIgnoreCase(length)) {
+                                return "20";
+                        }
+                        return "1";
+                } else if ("tinytext".equalsIgnoreCase(type)) {
+                        return "255";
+                } else if ("image".equalsIgnoreCase(type)) {
+                        return "8";
+                } else if ("datetimeoffset".equalsIgnoreCase(type)) {
+                        if ("4".equalsIgnoreCase(numericPrecision)) {
+                                return "31";
+                        }
+                        return "34";
+                } else if ("binary".equalsIgnoreCase(type)) {
+                        if ("8000".equalsIgnoreCase(length)) {
+                                return "8000";
+                        }
+                        if ("4".equalsIgnoreCase(length)) {
+                                return "4";
+                        }
+                        return "1";
+                } else if ("varbinary".equalsIgnoreCase(type)) {
+                        if ("8000".equalsIgnoreCase(length)) {
+                                return "8000";
+                        }
+                        if ("1".equalsIgnoreCase(length)) {
+                                return "1";
+                        }
+                        return "8";
+                } else if ("bit".equalsIgnoreCase(type)) {
+                        return "2";
+                } else if ("nchar".equalsIgnoreCase(type)) {
+                        if ("4000".equalsIgnoreCase(length)) {
+                                return "4000";
+                        }
+                        if ("10".equalsIgnoreCase(length)) {
+                                return "10";
+                        }
+                        return "1";
+                } else if ("real".equalsIgnoreCase(type)) {
+                        return "4";
+                } else if ("numeric".equalsIgnoreCase(type)) {
+                        if ("18".equalsIgnoreCase(dataPrecision)
+                                        || (null == dataScale || "0".equalsIgnoreCase(dataScale))) {
+                                return "8";
+                        }
+                        return "32";
+                } else if ("smalldatetime".equalsIgnoreCase(type)) {
+                        return "12";
+                } else if ("smallint".equalsIgnoreCase(type)) {
+                        return "2";
+                } else if ("time".equalsIgnoreCase(type)) {
+                        return "16";
+                } else if ("uniqueidentifier".equalsIgnoreCase(type)) {
+                        return "36";
+                } else if ("hierarchyid".equalsIgnoreCase(type)) {
+                        return "8";
+                }
+                return null;
+        }
 
-	public static String getMappedDefault(String type, String defaultValue) {
-		if (defaultValue != null) {
-			if (!"binary".equalsIgnoreCase(type)
-					&& !"varbinary".equalsIgnoreCase(type))
-				defaultValue = defaultValue.replaceAll("[()]", "");
-		}
-		if ("smallint".equalsIgnoreCase(type)
-				|| "mediumint".equalsIgnoreCase(type)
-				|| "bigint".equalsIgnoreCase(type)
-				|| "int".equalsIgnoreCase(type)
-				|| "tinyint".equalsIgnoreCase(type)
-				|| "numeric".equalsIgnoreCase(type)
-				|| "decimal".equalsIgnoreCase(type)
-				|| "money".equalsIgnoreCase(type)
-				|| "smallmoney".equalsIgnoreCase(type)
-				|| "real".equalsIgnoreCase(type)
-				|| "bit".equalsIgnoreCase(type)
-				|| "float".equalsIgnoreCase(type)) {
-			return defaultValue == null ? null : "'" + defaultValue + "'";
-		} else if ("timestamp".equalsIgnoreCase(type)) {
-			return "CURRENT_TIMESTAMP".equals(defaultValue) ? "'NOW'"
-					: defaultValue;
-		} else if ("binary".equalsIgnoreCase(type)
-				|| "varbinary".equalsIgnoreCase(type)) {
-			return defaultValue == null ? null : "'"
-					+ defaultValue.substring(defaultValue.indexOf('(') + 1,
-							defaultValue.lastIndexOf(')')) + "'";
-		}
-		return defaultValue;
-	}
+        public static String getMappedDefault(String type, String defaultValue) {
+                if (defaultValue != null) {
+                        if (!"binary".equalsIgnoreCase(type)
+                                        && !"varbinary".equalsIgnoreCase(type))
+                                defaultValue = defaultValue.replaceAll("[()]", "");
+                }
+                if ("smallint".equalsIgnoreCase(type)
+                                || "mediumint".equalsIgnoreCase(type)
+                                || "bigint".equalsIgnoreCase(type)
+                                || "int".equalsIgnoreCase(type)
+                                || "tinyint".equalsIgnoreCase(type)
+                                || "numeric".equalsIgnoreCase(type)
+                                || "decimal".equalsIgnoreCase(type)
+                                || "money".equalsIgnoreCase(type)
+                                || "smallmoney".equalsIgnoreCase(type)
+                                || "real".equalsIgnoreCase(type)
+                                || "bit".equalsIgnoreCase(type)
+                                || "float".equalsIgnoreCase(type)) {
+                        return defaultValue == null ? null : "'" + defaultValue + "'";
+                } else if ("timestamp".equalsIgnoreCase(type)) {
+                        return "CURRENT_TIMESTAMP".equals(defaultValue) ? "'NOW()'"
+                                        : defaultValue;
+                } else if ("binary".equalsIgnoreCase(type)
+                                || "varbinary".equalsIgnoreCase(type)) {
+                        return defaultValue == null ? null : "'"
+                                        + defaultValue.substring(defaultValue.indexOf('(') + 1,
+                                                        defaultValue.lastIndexOf(')')) + "'";
+                }
+                return defaultValue;
+        }
 
-	public boolean isCaseSensitive() {
-		return false;
-	}
+        public boolean isCaseSensitive() {
+                return false;
+        }
 }

--- a/core/src/test/java/com/nuodb/migrator/integration/types/SQLServerTypes.java
+++ b/core/src/test/java/com/nuodb/migrator/integration/types/SQLServerTypes.java
@@ -309,7 +309,7 @@ public class SQLServerTypes implements DatabaseTypes {
                                 || "float".equalsIgnoreCase(type)) {
                         return defaultValue == null ? null : "'" + defaultValue + "'";
                 } else if ("timestamp".equalsIgnoreCase(type)) {
-                        return "CURRENT_TIMESTAMP".equals(defaultValue) ? "'NOW()'"
+                        return "CURRENT_TIMESTAMP".equals(defaultValue) ? "NOW()"
                                         : defaultValue;
                 } else if ("binary".equalsIgnoreCase(type)
                                 || "varbinary".equalsIgnoreCase(type)) {

--- a/core/src/test/java/com/nuodb/migrator/jdbc/metadata/inspector/NuoDBColumnTriggerInspectorTest.java
+++ b/core/src/test/java/com/nuodb/migrator/jdbc/metadata/inspector/NuoDBColumnTriggerInspectorTest.java
@@ -78,7 +78,7 @@ public class NuoDBColumnTriggerInspectorTest extends InspectorTestBase {
         given(resultSet.getInt("TYPE_MASK")).willReturn(1);
         given(resultSet.getInt("ACTIVE")).willReturn(1);
         given(resultSet.getString("TABLENAME")).willReturn(tableName);
-        given(resultSet.getString("TRIGGER_TEXT")).willReturn("NEW.`f1` = 'NOW'; END_TRIGGER;");
+        given(resultSet.getString("TRIGGER_TEXT")).willReturn("NEW.`f1` = 'NOW()'; END_TRIGGER;");
         inspectionResults.addObject(table);
 
         TableInspectionScope inspectionScope = new TableInspectionScope(catalogName, schemaName, tableName );
@@ -93,7 +93,7 @@ public class NuoDBColumnTriggerInspectorTest extends InspectorTestBase {
         columnTrigger.setColumn(column);
         columnTrigger.setTriggerEvent(TriggerEvent.valueOf("INSERT"));
         columnTrigger.setTriggerTime(TriggerTime.valueOf("BEFORE"));
-        columnTrigger.setTriggerBody("NEW.`f1` = 'NOW'; END_TRIGGER");
+        columnTrigger.setTriggerBody("NEW.`f1` = 'NOW()'; END_TRIGGER");
 
         Table table1 = createTable(catalogName, schemaName, tableName);
         table1.addColumn(column);

--- a/core/src/test/java/com/nuodb/migrator/jdbc/metadata/inspector/NuoDBColumnTriggerInspectorTest.java
+++ b/core/src/test/java/com/nuodb/migrator/jdbc/metadata/inspector/NuoDBColumnTriggerInspectorTest.java
@@ -78,7 +78,7 @@ public class NuoDBColumnTriggerInspectorTest extends InspectorTestBase {
         given(resultSet.getInt("TYPE_MASK")).willReturn(1);
         given(resultSet.getInt("ACTIVE")).willReturn(1);
         given(resultSet.getString("TABLENAME")).willReturn(tableName);
-        given(resultSet.getString("TRIGGER_TEXT")).willReturn("NEW.`f1` = 'NOW()'; END_TRIGGER;");
+        given(resultSet.getString("TRIGGER_TEXT")).willReturn("NEW.`f1` = NOW(); END_TRIGGER;");
         inspectionResults.addObject(table);
 
         TableInspectionScope inspectionScope = new TableInspectionScope(catalogName, schemaName, tableName );
@@ -93,7 +93,7 @@ public class NuoDBColumnTriggerInspectorTest extends InspectorTestBase {
         columnTrigger.setColumn(column);
         columnTrigger.setTriggerEvent(TriggerEvent.valueOf("INSERT"));
         columnTrigger.setTriggerTime(TriggerTime.valueOf("BEFORE"));
-        columnTrigger.setTriggerBody("NEW.`f1` = 'NOW()'; END_TRIGGER");
+        columnTrigger.setTriggerBody("NEW.`f1` = NOW(); END_TRIGGER");
 
         Table table1 = createTable(catalogName, schemaName, tableName);
         table1.addColumn(column);


### PR DESCRIPTION
Starting in 3.4, 'NOW' produces 
`com.nuodb.migrator.backup.loader.BackupLoaderException: java.sql.SQLDataException: error converting NOW to Date/Time`