### PR TITLE
[MIG-174] Prompt for password if one is not provided in the options

### DIFF
--- a/core/src/main/java/com/nuodb/migrator/cli/processor/PasswordOptionProcessor.java
+++ b/core/src/main/java/com/nuodb/migrator/cli/processor/PasswordOptionProcessor.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2020, NuoDB, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of NuoDB, Inc. nor the names of its contributors may
+ *       be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NUODB, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.nuodb.migrator.cli.processor;
+
+import com.nuodb.migrator.cli.parse.CommandLine;
+import com.nuodb.migrator.cli.parse.Option;
+import com.nuodb.migrator.cli.parse.OptionException;
+import com.nuodb.migrator.utils.ConfigUtils;
+
+import java.io.Console;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.trimToNull;
+
+public class PasswordOptionProcessor extends ConfigOptionProcessor {
+    private String optionName;
+    private String password;
+
+    private String getPasswordFromPrompt(String prompt) {
+        Console console = System.console();
+        if (console == null) {
+            return null;
+        }
+        System.out.print(prompt);
+        return trimToNull(new String(console.readPassword()));
+    }
+
+    public PasswordOptionProcessor(String optionName) {
+        this.optionName = optionName;
+        password = null;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public void postProcess(CommandLine commandLine, Option option) {
+        password = (String)commandLine.getValue(optionName);
+        if (isEmpty(password)) {
+            // preProcess and process will *only* be called if the option is provided.
+            // Only postProcess is called whether or not the option is provided.
+            // We prompt if the option is provided but empty, or if it is not provided at all.
+            // So we must prompt from postProcess.
+            password = getPasswordFromPrompt("Enter " + optionName + ": ");
+            if (isEmpty(password)) {
+                throw new OptionException(
+                    format("Missing required option %s. The user's password should be provided", optionName),
+                    option);
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/nuodb/migrator/cli/run/CliSchemaJob.java
+++ b/core/src/main/java/com/nuodb/migrator/cli/run/CliSchemaJob.java
@@ -46,7 +46,6 @@ import static java.lang.Boolean.parseBoolean;
  */
 @SuppressWarnings("PointlessBooleanExpression")
 public class CliSchemaJob extends CliJob<SchemaJobSpec> {
-
     public CliSchemaJob() {
         super(SCHEMA);
     }
@@ -115,44 +114,5 @@ public class CliSchemaJob extends CliJob<SchemaJobSpec> {
             resource.setPath((String) optionSet.getValue(OUTPUT_PATH));
         }
         return resource;
-    }
-
-    @Override
-    protected Group createTargetGroup() {
-        GroupBuilder group = newGroupBuilder().withName(getMessage(TARGET_GROUP_NAME));
-
-        Option url = newBasicOptionBuilder().withName(TARGET_URL)
-                .withDescription(getMessage(TARGET_URL_OPTION_DESCRIPTION)).withArgument(newArgumentBuilder()
-                        .withName(getMessage(TARGET_URL_ARGUMENT_NAME)).withMinimum(1).withRequired(true).build())
-                .build();
-        group.withOption(url);
-
-        Option username = newBasicOptionBuilder().withName(TARGET_USERNAME)
-                .withDescription(getMessage(TARGET_USERNAME_OPTION_DESCRIPTION))
-                .withArgument(newArgumentBuilder().withName(getMessage(TARGET_USERNAME_ARGUMENT_NAME)).build()).build();
-        group.withOption(username);
-
-        Option password = newBasicOptionBuilder().withName(TARGET_PASSWORD)
-                .withDescription(getMessage(TARGET_PASSWORD_OPTION_DESCRIPTION))
-                .withArgument(newArgumentBuilder().withName(getMessage(TARGET_PASSWORD_ARGUMENT_NAME)).build()).build();
-        group.withOption(password);
-
-        Option properties = newBasicOptionBuilder().withName(TARGET_PROPERTIES)
-                .withDescription(getMessage(TARGET_PROPERTIES_OPTION_DESCRIPTION))
-                .withArgument(newArgumentBuilder().withName(getMessage(TARGET_PROPERTIES_ARGUMENT_NAME)).build())
-                .build();
-        group.withOption(properties);
-
-        Option schema = newBasicOptionBuilder().withName(TARGET_SCHEMA)
-                .withDescription(getMessage(TARGET_SCHEMA_OPTION_DESCRIPTION))
-                .withArgument(newArgumentBuilder().withName(getMessage(TARGET_SCHEMA_ARGUMENT_NAME)).build()).build();
-        group.withOption(schema);
-
-        Option autoCommit = newBasicOptionBuilder().withName(TARGET_AUTO_COMMIT)
-                .withDescription(getMessage(TARGET_AUTO_COMMIT_OPTION_DESCRIPTION))
-                .withArgument(newArgumentBuilder().withName(getMessage(TARGET_AUTO_COMMIT_ARGUMENT_NAME)).build())
-                .build();
-        group.withOption(autoCommit);
-        return group.build();
     }
 }

--- a/core/src/main/java/com/nuodb/migrator/cli/validation/NuoDBConnectionGroupValidator.java
+++ b/core/src/main/java/com/nuodb/migrator/cli/validation/NuoDBConnectionGroupValidator.java
@@ -82,11 +82,7 @@ public class NuoDBConnectionGroupValidator extends ConnectionGroupValidator {
 
     @Override
     protected void validatePassword(CommandLine commandLine, Option option, String password) {
-        if (isEmpty(password)) {
-            throw new OptionException(
-                    format("Missing required option %s. The user's password should be provided", getPasswordOption()),
-                    option);
-        }
+        // Validated in PasswordOptionProcessor
     }
 
     /**

--- a/core/src/test/java/com/nuodb/migrator/cli/run/CliDumpJobTest.java
+++ b/core/src/test/java/com/nuodb/migrator/cli/run/CliDumpJobTest.java
@@ -59,7 +59,7 @@ public class CliDumpJobTest {
     @Test
     public void testParse() {
         String[] arguments = { "--source.driver=com.mysql.jdbc.Driver", "--source.url=jdbc:mysql://localhost:3306/test",
-                "--source.username=root", "--source.password=", "--source.catalog=test",
+                "--source.username=root", "--source.password=12345", "--source.catalog=test",
                 "--source.properties=profileSQL=true",
 
                 "--output.path=/tmp/dump.cat", "--output.type=xml",
@@ -82,6 +82,7 @@ public class CliDumpJobTest {
         connectionSpec.setDriver("com.mysql.jdbc.Driver");
         connectionSpec.setUrl("jdbc:mysql://localhost:3306/test");
         connectionSpec.setUsername("root");
+        connectionSpec.setPassword("12345");
         connectionSpec.setCatalog("test");
 
         Map<String, Object> properties = new HashMap<String, Object>();

--- a/core/src/test/java/com/nuodb/migrator/cli/run/CliRunSupportTest.java
+++ b/core/src/test/java/com/nuodb/migrator/cli/run/CliRunSupportTest.java
@@ -98,13 +98,14 @@ public class CliRunSupportTest {
     @DataProvider(name = "sourceGroup")
     public Object[][] createSourceGroupData() {
         String[] arguments = { "--source.driver=com.mysql.jdbc.Driver", "--source.url=jdbc:mysql://localhost:3306/test",
-                "--source.username=root", "--source.password=", "--source.catalog=test",
+                "--source.username=root", "--source.password=12345", "--source.catalog=test",
                 "--source.properties=profileSQL=true" };
 
         DriverConnectionSpec expected = new DriverConnectionSpec();
         expected.setDriver("com.mysql.jdbc.Driver");
         expected.setUrl("jdbc:mysql://localhost:3306/test");
         expected.setUsername("root");
+        expected.setPassword("12345");
         expected.setCatalog("test");
 
         Map<String, Object> properties = Maps.newHashMap();


### PR DESCRIPTION
If source.password and/or target.password are not provided in the
options, prompt for them interactively. Password is not echoed.

If Console is not available (i.e., running in IDE or in test) then
password cannot be entered interactively and *must* be provided via
options.

Implemented by moving password validation into a new single
option-level validation (instead of group-level validation) attached
to each password option. This validation interactively prompts for
password if not provided in the options, and then throws
OptionException if password provided is still empty (after user
entry) or if console for interactive entry is unavailable.

A few tests modified to correctly test passing password in options.