### PR TITLE
add mariadb dialect as a slight modification to mysql dialect.

### DIFF
--- a/core/src/main/java/com/nuodb/migrator/jdbc/dialect/MariaDBDialect.java
+++ b/core/src/main/java/com/nuodb/migrator/jdbc/dialect/MariaDBDialect.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, NuoDB, Inc.
+ * Copyright (c) 2023, NuoDB, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,35 +28,20 @@
 package com.nuodb.migrator.jdbc.dialect;
 
 import com.nuodb.migrator.jdbc.metadata.DatabaseInfo;
-import com.nuodb.migrator.jdbc.metadata.resolver.SimpleCachingServiceResolver;
 
-import static com.nuodb.migrator.jdbc.metadata.DatabaseInfos.*;
-import static com.nuodb.migrator.utils.ReflectionUtils.newInstance;
+import java.sql.SQLException;
+import java.sql.Statement;
 
-/**
- * @author Sergey Bushik
- */
-public class SimpleDialectResolver extends SimpleCachingServiceResolver<Dialect> implements DialectResolver {
 
-    public SimpleDialectResolver() {
-        super(SimpleDialect.class);
-        register(DB2, DB2Dialect.class);
-        register(MYSQL, MySQLDialect.class);
-        register(MARIADB, MariaDBDialect.class);
-        register(NUODB_BASE, NuoDBDialect.class);
-        register(NUODB_203, NuoDBDialect203.class);
-        register(NUODB_206, NuoDBDialect206.class);
-        register(NUODB_256, NuoDBDialect256.class);
-        register(NUODB_320, NuoDBDialect320.class);
-        register(NUODB, NuoDBDialect340.class);
-        register(POSTGRE_SQL, PostgreSQLDialect.class);
-        register(ORACLE, OracleDialect.class);
-        register(MSSQL_SERVER, MSSQLServerDialect.class);
-        register(MSSQL_SERVER_2005, MSSQLServer2005Dialect.class);
+public class MariaDBDialect extends MySQLDialect {
+
+    public MariaDBDialect(DatabaseInfo databaseInfo) {
+        super(databaseInfo);
     }
 
     @Override
-    protected Dialect createService(Class<? extends Dialect> serviceClass, DatabaseInfo databaseInfo) {
-        return newInstance(serviceClass, databaseInfo);
+    public void setFetchMode(Statement statement, FetchMode fetchMode) throws SQLException {
+	int fetchSize = fetchMode.isStream() ? 1 : fetchMode.getFetchSize();
+	statement.setFetchSize(fetchSize);
     }
 }

--- a/core/src/main/java/com/nuodb/migrator/jdbc/metadata/DatabaseInfos.java
+++ b/core/src/main/java/com/nuodb/migrator/jdbc/metadata/DatabaseInfos.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang3.StringUtils;
  */
 public interface DatabaseInfos {
     final DatabaseInfo MYSQL = new DatabaseInfo("MySQL");
+    final DatabaseInfo MARIADB = new DatabaseInfo("MariaDB");
     final DatabaseInfo NUODB_BASE = new NuoDBDatabaseInfo("NuoDB");
     final DatabaseInfo NUODB_203 = new NuoDBDatabaseInfo("NuoDB", null, 2, 0, 29);
     final DatabaseInfo NUODB_204 = new NuoDBDatabaseInfo("NuoDB", null, 2, 0, 30);


### PR DESCRIPTION
3DS Dashboarding is asking to migrate from mariadb to nuodb.   This will allow use from mariadb jdbc driver.   Although it should be possible to migrate without this by using the mysql jdbc driver. 