### PR TITLE
Revert "Bump simple-xml from 2.6.6 to 2.7.1 in /core"

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.simpleframework</groupId>
             <artifactId>simple-xml</artifactId>
-            <version>2.7.1</version>
+            <version>2.6.6</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>


### PR DESCRIPTION
Reverts nuodb/migration-tools#63

Test failure when using new version of component:

`
testWrite(com.nuodb.migrator.backup.XmlBackupTest)  Time elapsed: 0.008 sec  <<< FAILURE!
com.nuodb.migrator.utils.xml.XmlPersisterException: org.simpleframework.xml.core.ConstructorException: Default constructor can not accept read only @org.simpleframework.xml.ElementMap(required=false, name=, value=, data=false, empty=true, entry=, key=,
 keyType=void, valueType=void, attribute=false, inline=false) on field 'catalogs' private final java.util.Map com.nuodb.migrator.jdbc.metadata.Database.catalogs in class com.nuodb.migrator.jdbc.metadata.Database
        at org.simpleframework.xml.core.InstantiatorBuilder.validateConstructors(InstantiatorBuilder.java:362)
        at org.simpleframework.xml.core.InstantiatorBuilder.validateConstructors(InstantiatorBuilder.java:339)
        at org.simpleframework.xml.core.InstantiatorBuilder.validate(InstantiatorBuilder.java:253)
        at org.simpleframework.xml.core.InstantiatorBuilder.build(InstantiatorBuilder.java:114)
        at org.simpleframework.xml.core.StructureBuilder.commit(StructureBuilder.java:483)
        at org.simpleframework.xml.core.ObjectScanner.validate(ObjectScanner.java:418)
        at org.simpleframework.xml.core.ObjectScanner.scan(ObjectScanner.java:373)
        at org.simpleframework.xml.core.ObjectScanner.<init>(ObjectScanner.java:82)
        at org.simpleframework.xml.core.DefaultScanner.<init>(DefaultScanner.java:64)
        at org.simpleframework.xml.core.ScannerFactory.getInstance(ScannerFactory.java:84)
        at org.simpleframework.xml.core.Support.getScanner(Support.java:357)
        at org.simpleframework.xml.core.Support.getName(Support.java:419)
        at org.simpleframework.xml.core.Source.getName(Source.java:240)
        at org.simpleframework.xml.core.Traverser.getName(Traverser.java:284)
        at org.simpleframework.xml.core.Traverser.write(Traverser.java:203)
        at org.simpleframework.xml.core.Traverser.write(Traverser.java:186)
        at org.simpleframework.xml.core.Persister.write(Persister.java:1180)
        at org.simpleframework.xml.core.Persister.write(Persister.java:1162)
        at org.simpleframework.xml.core.Persister.write(Persister.java:1140)
        at org.simpleframework.xml.core.Persister.write(Persister.java:1259)
        at com.nuodb.migrator.utils.xml.XmlPersister.write(XmlPersister.java:98)
        at com.nuodb.migrator.utils.xml.XmlPersister.write(XmlPersister.java:93)
        at com.nuodb.migrator.backup.XmlBackupTest.testWrite(XmlBackupTest.java:249)
`