### PR TITLE
Make target.driver optional and adjust tests to no longer expect it

### DIFF
--- a/core/src/main/java/com/nuodb/migrator/cli/run/CliRunSupport.java
+++ b/core/src/main/java/com/nuodb/migrator/cli/run/CliRunSupport.java
@@ -300,6 +300,7 @@ public class CliRunSupport extends CliSupport {
 
         Option driver = newBasicOptionBuilder().withName(TARGET_DRIVER)
                 .withDescription(getMessage(TARGET_DRIVER_OPTION_DESCRIPTION))
+                .withRequired(false)
                 .withArgument(newArgumentBuilder().withName(getMessage(TARGET_DRIVER_ARGUMENT_NAME)).withRequired(true)
                         .withMinimum(1).withOptionFormat(optionFormat).build())
                 .build();

--- a/core/src/test/java/com/nuodb/migrator/cli/run/CliLoadJobTest.java
+++ b/core/src/test/java/com/nuodb/migrator/cli/run/CliLoadJobTest.java
@@ -79,7 +79,6 @@ public class CliLoadJobTest {
         LoadJobSpec loadJobSpec = new LoadJobSpec();
 
         DriverConnectionSpec connectionSpec = new DriverConnectionSpec();
-        connectionSpec.setDriver(NUODB_DRIVER);
         connectionSpec.setUrl("jdbc:com.nuodb://localhost/test?schema=hockey");
         connectionSpec.setUsername("dba");
         connectionSpec.setPassword("goalie");

--- a/core/src/test/java/com/nuodb/migrator/cli/run/CliRunSupportTest.java
+++ b/core/src/test/java/com/nuodb/migrator/cli/run/CliRunSupportTest.java
@@ -163,7 +163,6 @@ public class CliRunSupportTest {
                 "--target.password=goalie", "--target.schema=hockey" };
 
         DriverConnectionSpec expected = new DriverConnectionSpec();
-        expected.setDriver(JdbcConstants.NUODB_DRIVER);
         expected.setUrl("jdbc:com.nuodb://localhost/test");
         expected.setUsername("dba");
         expected.setPassword("goalie");

--- a/core/src/test/java/com/nuodb/migrator/cli/run/CliSchemaJobTest.java
+++ b/core/src/test/java/com/nuodb/migrator/cli/run/CliSchemaJobTest.java
@@ -94,7 +94,6 @@ public class CliSchemaJobTest {
         schemaSpec.setSourceSpec(sourceConnectionSpec);
 
         DriverConnectionSpec targetConnectionSpec = new DriverConnectionSpec();
-        targetConnectionSpec.setDriver(NUODB_DRIVER);
         targetConnectionSpec.setUrl("jdbc:com.nuodb://localhost/test");
         targetConnectionSpec.setUsername("dba");
         targetConnectionSpec.setPassword("goalie");


### PR DESCRIPTION
target.driver was intended to be optional, make it so.

A few tests needed their expected parse results adjusted since we (correctly) no longer default the target driver to NuoDB regardless of target url.