### PR TITLE
Update dependencies to fix security vulnerabilities

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>de.undercouch</groupId>
             <artifactId>bson4jackson</artifactId>
-            <version>2.4.0</version>
+            <version>2.13.1</version>
         </dependency>
         <dependency>
             <groupId>commons-dbcp</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.7</version>
+            <version>1.13</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.7</version>
+            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.4.1</version>
+            <version>2.15.2</version>
         </dependency>
         <dependency>
             <groupId>de.undercouch</groupId>


### PR DESCRIPTION
Upgrade components due to security vulnerabilities

    - com.fasterxml.jackson.core:jackson-databind from 2.4.1 to 2.9.10.4
    - commons-io:commons-io from 2.7 to 2.8.0-RC1
    - commons-codec:commons-codec from 1.7 to 1.13
    
Version 2.4.0 of de.undercouch.bson4jackson depends on jackson-databind v2.4.1 which has Critical vulnerabilities.
Bumped to latest version 2.13.1 which also dependes on a version of jackson-databind v2.13.0 but this time the severity is High.

It is now down to 9 vulns detected 1 of which is critical: org.simpleframework:simple-xml v2.6.6
```
Vulnerabilities
┌────────────┬─────────────────────┬──────────┬───────┬──────────────────┬────────────────────┬───────────┬──────────────────┐
│ SEVERITY   │ IMPACTED            │ IMPACTED │ TYPE  │ FIXED            │ COMPONENT          │ COMPONENT │ CVE              │
│            │ PACKAGE             │ PACKAGE  │       │ VERSIONS         │                    │ VERSION   │                  │
│            │                     │ VERSION  │       │                  │                    │           │                  │
├────────────┼─────────────────────┼──────────┼───────┼──────────────────┼────────────────────┼───────────┼──────────────────┤
│ 💀Critical │ org.simpleframework │ 2.6.6    │ Maven │ [2.7.1]          │ nuodb-migrator.zip │           │ CVE-2017-1000190 │
│            │ :simple-xml         │          │       │                  │                    │           │                  │
├────────────┼─────────────────────┼──────────┼───────┼──────────────────┼────────────────────┼───────────┼──────────────────┤
│ 🔥High     │ com.fasterxml.jacks │ 2.13.0   │ Maven │ [2.12.6]         │ nuodb-migrator.zip │           │ CVE-2021-46877   │
│            │ on.core:jackson-dat │          │       │ [2.13.1]         │                    │           │                  │
│            │ abind               │          │       │                  │                    │           │                  │
├────────────┼─────────────────────┼──────────┼───────┼──────────────────┼────────────────────┼───────────┼──────────────────┤
│ 🔥High     │ com.fasterxml.jacks │ 2.13.0   │ Maven │ [2.12.6.1]       │ nuodb-migrator.zip │           │ CVE-2020-36518   │
│            │ on.core:jackson-dat │          │       │ [2.13.2.1]       │                    │           │                  │
│            │ abind               │          │       │                  │                    │           │                  │
├────────────┼─────────────────────┼──────────┼───────┼──────────────────┼────────────────────┼───────────┼──────────────────┤
│ 🔥High     │ com.fasterxml.jacks │ 2.13.0   │ Maven │ [2.12.7.1]       │ nuodb-migrator.zip │           │ CVE-2022-42003   │
│            │ on.core:jackson-dat │          │       │ [2.13.4.1]       │                    │           │                  │
│            │ abind               │          │       │ [2.14.0]         │                    │           │                  │
├────────────┼─────────────────────┼──────────┼───────┼──────────────────┼────────────────────┼───────────┼──────────────────┤
│ 🔥High     │ com.google.guava:gu │ 13.0     │ Maven │ [32.0.1-android] │ nuodb-migrator.zip │           │ CVE-2023-2976    │
│            │ ava                 │          │       │ [32.0.1-jre]     │                    │           │                  │
├────────────┼─────────────────────┼──────────┼───────┼──────────────────┼────────────────────┼───────────┼──────────────────┤
│ 🔥High     │ com.fasterxml.jacks │ 2.13.0   │ Maven │ [2.12.7.1]       │ nuodb-migrator.zip │           │ CVE-2022-42004   │
│            │ on.core:jackson-dat │          │       │ [2.13.4]         │                    │           │                  │
│            │ abind               │          │       │                  │                    │           │                  │
├────────────┼─────────────────────┼──────────┼───────┼──────────────────┼────────────────────┼───────────┼──────────────────┤
│ 🎃Medium   │ com.fasterxml.jacks │ 2.13.0   │ Maven │                  │ nuodb-migrator.zip │           │ CVE-2023-35116   │
│            │ on.core:jackson-dat │          │       │                  │                    │           │                  │
│            │ abind               │          │       │                  │                    │           │                  │
├────────────┼─────────────────────┼──────────┼───────┼──────────────────┼────────────────────┼───────────┼──────────────────┤
│ 🎃Medium   │ com.google.guava:gu │ 13.0     │ Maven │ [24.1.1]         │ nuodb-migrator.zip │           │ CVE-2018-10237   │
│            │ ava                 │          │       │                  │                    │           │                  │
├────────────┼─────────────────────┼──────────┼───────┼──────────────────┼────────────────────┼───────────┼──────────────────┤
│ 👻Low      │ com.google.guava:gu │ 13.0     │ Maven │                  │ nuodb-migrator.zip │           │ CVE-2020-8908    │
│            │ ava                 │          │       │                  │                    │           │                  │
└────────────┴─────────────────────┴──────────┴───────┴──────────────────┴────────────────────┴───────────┴──────────────────┘
```

